### PR TITLE
Issue #7: Add chart display

### DIFF
--- a/classes/collector/base.php
+++ b/classes/collector/base.php
@@ -42,4 +42,11 @@ abstract class base {
      * @return bool
      */
     abstract public function is_ready(): bool;
+
+    /**
+     * @param mixed $metrics The metrics to be retrieved. Either a single string, or an
+     *         array of strings. If null, then all available metrics will be retrieved.
+     * @return array|bool
+     */
+    abstract public function get_metrics($metrics = null);
 }

--- a/cli/add_metrics.php
+++ b/cli/add_metrics.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use tool_cloudmetrics\metric\test_metric;
+use tool_cloudmetrics\collector;
+
+/**
+ * Generate mock metric data to send to collectors.
+ *
+ * @package   tool_cloudmetrics
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+
+require_once(__DIR__ . '/../../../../config.php');
+require_once($CFG->libdir.'/clilib.php');
+
+// Get cli options.
+list($options, $unrecognized) = cli_get_params(
+    [
+        'help' => false,
+        'name' => false,
+    ], [
+        'h' => 'help',
+        'n' => 'name',
+    ]
+);
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    $help =
+        "Add metrics.
+
+Generate mock metric data to fill collectors with.
+Do not use with production environments.
+
+Options:
+-h, --help               Print out this help
+-n, --name               The name of the metric being mocked.
+
+Example:
+\$sudo -u www-data /usr/bin/php admin/tool/cloudmetrics/cli/add_metrics.php --name=activeusers
+";
+
+    echo $help;
+    die;
+}
+
+
+
+$metric = new test_metric();
+$metric->name = $options['name'];
+
+for ($i = 0; $i < 100; ++$i) {
+    $item = $metric->get_metric_item();
+    collector\manager::send_metric($item);
+}

--- a/collector/database/chart.php
+++ b/collector/database/chart.php
@@ -26,7 +26,7 @@ use tool_cloudmetrics\metric;
  */
 
 require_once(__DIR__.'/../../../../../config.php');
-require_once($CFG->libdir.'/adminlib.php');
+require_once($CFG->libdir . '/adminlib.php');
 
 admin_externalpage_setup('cltr_database_chart');
 
@@ -39,7 +39,7 @@ $PAGE->set_url($url);
 
 $metricname = optional_param('metric', 'activeusers', PARAM_ALPHANUMEXT);
 
-$metrics = metric\manager::get_metrics();
+$metrics = metric\manager::get_metrics(true);
 $metriclabels = [];
 foreach ($metrics as $metric) {
     $metriclabels[$metric->get_name()] = $metric->get_label();
@@ -53,7 +53,8 @@ $select = new \single_select(
 );
 $select->set_label(get_string('select_metric_for_display', 'cltr_database'));
 
-$records = $DB->get_records('cltr_database_metrics', ['name' => $metricname], 'time asc', 'id, time, value');
+$collector = new \cltr_database\collector();
+$records = $collector->get_metrics($metricname);
 
 $values = [];
 $labels = [];
@@ -69,8 +70,7 @@ $chart = new \core\chart_line();
 $chart->add_series($chartseries);
 $chart->set_labels($labels);
 
-$output = $PAGE->get_renderer('core');
-echo $output->header();
-echo $output->render($select);
-echo $output->render($chart);
-echo $output->footer();
+echo $OUTPUT->header();
+echo $OUTPUT->render($select);
+echo $OUTPUT->render($chart);
+echo $OUTPUT->footer();

--- a/collector/database/chart.php
+++ b/collector/database/chart.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use tool_cloudmetrics\metric;
+
+/**
+ * Shows a chart of recorded metrics.
+ *
+ * @package   cltr_database
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__.'/../../../../../config.php');
+require_once($CFG->libdir.'/adminlib.php');
+
+admin_externalpage_setup('cltr_database_chart');
+
+$context = context_system::instance();
+
+$url = new moodle_url('/admin/tool/cloudmetrics/collector/database/chart.php');
+
+$PAGE->set_context($context);
+$PAGE->set_url($url);
+
+$metricname = optional_param('metric', 'activeusers', PARAM_ALPHANUMEXT);
+
+$metrics = metric\manager::get_metrics();
+$metriclabels = [];
+foreach ($metrics as $metric) {
+    $metriclabels[$metric->get_name()] = $metric->get_label();
+}
+
+$select = new \single_select(
+    $url,
+    'metric',
+    $metriclabels,
+    $metricname
+);
+$select->set_label(get_string('select_metric_for_display', 'cltr_database'));
+
+$records = $DB->get_records('cltr_database_metrics', ['name' => $metricname], 'time asc', 'id, time, value');
+
+$values = [];
+$labels = [];
+
+foreach ($records as $record) {
+    $values[] = (float) $record->value;
+    $labels[] = userdate($record->time, get_string('strftimedatetimeshort'), $CFG->timezone);
+}
+
+$chartseries = new \core\chart_series($metriclabels[$metricname], $values);
+
+$chart = new \core\chart_line();
+$chart->add_series($chartseries);
+$chart->set_labels($labels);
+
+$output = $PAGE->get_renderer('core');
+echo $output->header();
+echo $output->render($select);
+echo $output->render($chart);
+echo $output->footer();

--- a/collector/database/lang/en/cltr_database.php
+++ b/collector/database/lang/en/cltr_database.php
@@ -36,6 +36,7 @@ $string['metric_expiry'] = 'Time to keep data';
 $string['metric_expiry_desc'] = 'Length of time to keep data before deleting.';
 
 // Chart display.
+$string['metric_display'] = 'Metric Display';
 $string['select_metric_for_display'] = 'Select metric for display.';
 
 // Scheduled tasks.

--- a/collector/database/lang/en/cltr_database.php
+++ b/collector/database/lang/en/cltr_database.php
@@ -36,7 +36,7 @@ $string['metric_expiry'] = 'Time to keep data';
 $string['metric_expiry_desc'] = 'Length of time to keep data before deleting.';
 
 // Chart display.
-$string['metric_display'] = 'Metric Display';
+$string['metric_display'] = 'Cloudmetrics Charts';
 $string['select_metric_for_display'] = 'Select metric for display.';
 
 // Scheduled tasks.

--- a/collector/database/settings.php
+++ b/collector/database/settings.php
@@ -26,10 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
-    $ADMIN->add('reports', new admin_category('cltr_database_reports', get_string('pluginname', 'cltr_database')));
-
     $ADMIN->add(
-        'cltr_database_reports',
+        'reports',
         new admin_externalpage(
             'cltr_database_chart',
             get_string('metric_display', 'cltr_database'),

--- a/collector/database/settings.php
+++ b/collector/database/settings.php
@@ -26,6 +26,18 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
+    $ADMIN->add('reports', new admin_category('cltr_database_reports', get_string('pluginname', 'cltr_database')));
+
+    $ADMIN->add(
+        'cltr_database_reports',
+        new admin_externalpage(
+            'cltr_database_chart',
+            get_string('metric_display', 'cltr_database'),
+            new moodle_url('/admin/tool/cloudmetrics/collector/database/chart.php'),
+            'moodle/site:config'
+        )
+    );
+
     if ($ADMIN->fulltree) {
         $settings->add(
             new admin_setting_configduration(

--- a/collector/database/tests/cltr_database_test.php
+++ b/collector/database/tests/cltr_database_test.php
@@ -101,11 +101,17 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
         $this->assertEquals('mock', $rec[1]->name);
         $this->assertEquals('2', $rec[1]->value);
 
+        // Should get the same result with get_metrics().
+        $rec = array_values($collector->get_metrics('mock'));
+        $this->assertEquals(2, count($rec));
+        $this->assertEquals('1', $rec[0]->value);
+        $this->assertEquals('2', $rec[1]->value);
+
         $collector->record_metric($stub->get_metric_item());
         $collector->record_metric($stub->get_metric_item());
 
         // Should have four metrics of values 1, 2, 3 & 1.
-        $rec = array_values($DB->get_records(lib::TABLE, null, 'time ASC'));
+        $rec = array_values($collector->get_metrics('mock'));
         $this->assertEquals(4, count($rec));
         $this->assertEquals('1', $rec[0]->value);
         $this->assertEquals('2', $rec[1]->value);

--- a/collector/database/version.php
+++ b/collector/database/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022031601;
+$plugin->version = 2022040500;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->component = 'cltr_database';
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022031401;
+$plugin->version = 2022040500;
 $plugin->release = 2022031400;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).


### PR DESCRIPTION
Add chart display page
Add listing to site administration reports

This PR includes a CLI script to send fake values to the collectors.

```
php admin/tool/cloudmetrics/cli/add_metrics.php --metric=activeusers
```

To run it you need to have a CFG value set to a non empty value. This prevents accidental running in prod environments.
The setting is `$CFG->config_php_settings['tool_cloudmetrics_allow_add_metrics'] =1;`.

You run it with a name to 'fake' the metric. i.e. `add_metrics.php --name=activeusers`.
There are other options. Use `--help` to list them.

After this you should be able to see the values on the charts page. (Site Administration -> Reports -> Reports -> Cloudmetrics charts).

IMO, the Charts API is very primitive, and recommend that, at some future date, something like D3 be used instead.