### PR TITLE
Issue #49: Refactor to use only one call to Cloudwatch API for many metrics

### DIFF
--- a/classes/collector/base.php
+++ b/classes/collector/base.php
@@ -37,6 +37,18 @@ abstract class base {
     abstract public function record_metric(metric_item $metric);
 
     /**
+     * Records a number of metrics.
+     *
+     * @param array $metrics
+     * @return mixed
+     */
+    public function record_metrics(array $metrics) {
+        foreach ($metrics as $metric) {
+            $this->record_metric($metric);
+        }
+    }
+
+    /**
      * Returns true if the backend service is able to receive submissions.
      *
      * @return bool

--- a/classes/collector/manager.php
+++ b/classes/collector/manager.php
@@ -47,9 +47,7 @@ class manager {
         foreach ($plugins as $plugin) {
             $collector = $plugin->get_collector();
             if ($collector->is_ready()) {
-                foreach ($items as $item) {
-                    $collector->record_metric($item);
-                }
+                $collector->record_metrics($items);
             }
         }
     }

--- a/cli/add_metrics.php
+++ b/cli/add_metrics.php
@@ -101,6 +101,7 @@ if (!empty($options['remove'])) {
     for ($i = 0; $i < $num; ++$i) {
         $item = $metric->get_metric_item();
         echo 'Sending item ' . $item->name . ', ' . $item->value . ',' . userdate($item->time) . "\n";
-        collector\manager::send_metrics([$item]);
+        $items[] = $item;
     }
+    collector\manager::send_metrics($items);
 }

--- a/collector/cloudwatch/classes/collector.php
+++ b/collector/cloudwatch/classes/collector.php
@@ -64,21 +64,40 @@ class collector extends base {
     public function record_metric(metric_item $item) {
         self::$client->putMetricData([
             'Namespace' => self::$pluginconfig->namespace,
-            'MetricData' => [
+            'MetricData' => [ $this->make_metric_data_entry($item) ],
+        ]);
+    }
+
+    public function record_metrics(array $items) {
+        $metricdata = [];
+        foreach ($items as $item) {
+            $metricdata[] = $this->make_metric_data_entry($item);
+        }
+        self::$client->putMetricData([
+            'Namespace' => self::$pluginconfig->namespace,
+            'MetricData' => $metricdata,
+        ]);
+    }
+
+    /**
+     * Creates a metric data array from an item for use with the Cloudwatch API.
+     *
+     * @param metric_item $item
+     * @return array
+     */
+    private function make_metric_data_entry(metric_item $item): array {
+        return [
+            'MetricName' => $item->name,
+            'Value' => $item->value,
+            'Unit' => $item->unit ?? 'Count',
+            'Timestamp' => $item->time,
+            'Dimensions' => [
                 [
-                    'MetricName' => $item->name,
-                    'Value' => $item->value,
-                    'Unit' => $item->unit ?? 'Count',
-                    'Timestamp' => $item->time,
-                    'Dimensions' => [
-                        [
-                            'Name' => 'Environment',
-                            'Value' => self::$pluginconfig->environment,
-                        ],
-                    ],
+                    'Name' => 'Environment',
+                    'Value' => self::$pluginconfig->environment,
                 ],
             ],
-        ]);
+        ];
     }
 
     public function is_ready(): bool {

--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -143,22 +143,22 @@ class tool_cloudmetrics_collect_metrics_test extends \advanced_testcase {
             [
                 'midnight +75 minutes',
                 [manager::FREQ_15MIN, manager::FREQ_5MIN, manager::FREQ_HOUR],
-                ['activeusers', 'newusers']
+                ['newusers', 'activeusers']
             ],
             [
                 'midnight +60 minutes',
                 [manager::FREQ_15MIN, manager::FREQ_5MIN, manager::FREQ_HOUR],
-                ['activeusers', 'newusers', 'onlineusers']
+                ['newusers', 'activeusers', 'onlineusers']
             ],
             [
                 'midnight this month',
                 [manager::FREQ_MONTH, manager::FREQ_15MIN, manager::FREQ_HOUR],
-                ['activeusers', 'newusers', 'onlineusers']
+                ['newusers', 'onlineusers', 'activeusers']
             ],
             [
                 'midnight this month -10 seconds',
                 [manager::FREQ_MONTH, manager::FREQ_15MIN, manager::FREQ_HOUR],
-                ['activeusers', 'newusers', 'onlineusers']
+                ['newusers', 'onlineusers', 'activeusers']
             ],
             [
                 'midnight this month +15 minutes',


### PR DESCRIPTION
Resolves #49 

Add collector\base::record_metrics()
Modify collector\manager to use above function.
Override record_metrics() in cltr_cloudwatch\collector.
Fix PHPUnit failure.