### PR TITLE
  Issue #75; Disable AWS cloudwatch plugin for cloudmetrics by default.

### DIFF
--- a/classes/plugininfo/cltr.php
+++ b/classes/plugininfo/cltr.php
@@ -76,7 +76,7 @@ class cltr extends \core\plugininfo\base {
      * @return null|bool
      */
     public function is_enabled(): bool {
-        return !((bool) get_config('cltr_' . $this->name, 'disabled'));
+        return ((bool) get_config('cltr_' . $this->name, 'enabled'));
     }
 
     /**
@@ -86,7 +86,7 @@ class cltr extends \core\plugininfo\base {
      */
     public function set_enabled(bool $enable) {
         if ($this->is_enabled() != $enable) {
-            set_config('disabled', (int) !$enable, 'cltr_' . $this->name);
+            set_config('enabled', (int) $enable, 'cltr_' . $this->name);
             \core_plugin_manager::reset_caches();
         }
     }

--- a/collector/database/db/install.php
+++ b/collector/database/db/install.php
@@ -15,25 +15,15 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version
+ * Install script for cloudmetrics.
  *
  * @package   tool_cloudmetrics
- * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
- * @copyright  2022, Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author    Mike Macgirvin <mikemacgirvin@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version = 2022051600;
-$plugin->release = 2022051600;
-
-$plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
-
-$plugin->supported = [35, 401];     // Available as of Moodle 3.9.0 or later.
-// TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.
-
-$plugin->component = 'tool_cloudmetrics';
-$plugin->maturity = MATURITY_ALPHA;
-
-$plugin->dependencies = [];
+function xmldb_cltr_database_install() {
+    set_config('enabled', 1, 'cltr_database');
+    \core_plugin_manager::reset_caches();
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -24,12 +24,25 @@
  */
 
 function xmldb_tool_cloudmetrics_upgrade($oldversion) {
-    global $DB;
+    global $DB, $CFG;
 
     $dbman = $DB->get_manager();
 
     // Automatically generated Moodle v3.11.0 release upgrade line.
     // Put any upgrade step following this.
+    if ($oldversion < 2022051600) {
+        // Reverse the logic of existing disabled settings.
+        foreach (['cloudwatch', 'database'] as $connector) {
+            $x = get_config('cltr_' . $collector, 'disabled');
+            // Never used. Default is now disabled, so leave alone.
+            if ($x === false) {
+                continue;
+            }
+            set_config('enabled', 1 - (int) $x, 'cltr_' . $collector);
+            unset_config('disabled', 'cltr_' . $collector);
+        }
+        upgrade_plugin_savepoint(true, 2022051600, 'tool', 'cloudmetrics');
+    }
 
     return true;
 }


### PR DESCRIPTION
  Issue #75; Disable AWS cloudwatch plugin for cloudmetrics by default.
  It is automatically enabled when installed with cloudmetrics.