### PR TITLE
Monthsecs constant add

### DIFF
--- a/collector/database/chart.php
+++ b/collector/database/chart.php
@@ -24,6 +24,7 @@ use tool_cloudmetrics\metric;
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+define('MONTHSECS', WEEKSECS * 4);
 
 require_once(__DIR__.'/../../../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');


### PR DESCRIPTION
Hi @jaypha,

This is a fix for a constant used in the collector/database/chart.php, 
`Warning: Use of undefined constant MONTHSECS - assumed 'MONTHSECS' (this will throw an Error in a future version of PHP) in /admin/tool/cloudmetrics/collector/database/chart.php on line 79`,
`Warning: A non-numeric value encountered`, it seems this constant is not defined in lib/moodlelib.php.

Regards,

Marc