### PR TITLE
Issue #106: Incorrect data returned by cltr::get_enabled_plugins() causes unit test failure in Moodle

### DIFF
--- a/classes/plugininfo/cltr.php
+++ b/classes/plugininfo/cltr.php
@@ -38,12 +38,18 @@ class cltr extends \core\plugininfo\base {
      */
     public static function get_enabled_plugins() {
         $plugins = \core_plugin_manager::instance()->get_plugins_of_type('cltr');
+
+        if (empty($plugins)) {
+            return array();
+        }
+
+        $enabled = array();
         foreach ($plugins as $name => $plugin) {
-            if (!$plugin->is_enabled()) {
-                unset($plugins[$name]);
+            if ($plugin->is_enabled()) {
+                $enabled[$name] = $name;
             }
         }
-        return $plugins;
+        return $enabled;
     }
 
     /**


### PR DESCRIPTION
This is PR for Issue #106

The patch fixes the result for cltr::get_enabled_plugins().
The function cltr::get_enabled_plugins() is supposed to return the array of enabled plugins as $pluginname=>$pluginname.
Returning array of plugin objects is incorrect.

The error message and instructions to repeat can be found in the description of Issue #106.

After applying the fix, the test passes successfully:
```
root@a98befdc0147:/var/www/moodletest# vendor/bin/phpunit "core_plugin_manager_testcase" lib/tests/_manager_test.php
Moodle 3.9.14+ (Build: 20220701), 1b0ca9c4ded8c25141a6a62b728323800ca036c8
Php: 7.4.29, pgsql: 9.6.24, OS: Linux 5.15.0-37-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

.........................................                         41 / 41 (100%)

Time: 5 seconds, Memory: 93.00 MB

OK (41 tests, 6620 assertions)
```