### PR TITLE
Issue #106: Incorrect data returned by cltr::get_enabled_plugins() causes uses unit test failure in Moodle #107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,4 +5,5 @@ on: [push, pull_request]
 
 jobs:
   ci:
+    # change this back to @main after testing
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main

--- a/classes/collector/manager.php
+++ b/classes/collector/manager.php
@@ -46,7 +46,7 @@ class manager {
      * @param array $items An array of metric_item.
      */
     public static function send_metrics(array $items) {
-        $plugins = cltr::get_enabled_plugins();
+        $plugins = cltr::get_enabled_plugin_instances();
         if (!$plugins) {
             mtrace('No collectors to send metrics to!');
             return;

--- a/classes/plugininfo/cltr.php
+++ b/classes/plugininfo/cltr.php
@@ -33,10 +33,32 @@ class cltr extends \core\plugininfo\base {
     ];
 
     /**
-     * Finds all enabled plugins, the result may include missing plugins.
+     * Finds all enabled plugin names, the result may include missing plugins.
      * @return array|null of enabled plugins $pluginname=>$pluginname, null means unknown
      */
     public static function get_enabled_plugins() {
+        $plugins = \core_plugin_manager::instance()->get_plugins_of_type('cltr');
+
+        if (empty($plugins)) {
+            return array();
+        }
+
+        $enabled = [];
+        foreach ($plugins as $name => $plugin) {
+            if ($plugin->is_enabled()) {
+                $enabled[$name] = $name;
+            }
+        }
+        return $enabled;
+    }
+
+    /**
+     * Finds all enabled plugin instances of 'cltr', the result may include
+     * missing plugins.
+     * @return array of enabled plugin objects. Empty array means plugin is not
+     * enabled or missing
+     */
+    public static function get_enabled_plugin_instances() {
         $plugins = \core_plugin_manager::instance()->get_plugins_of_type('cltr');
         foreach ($plugins as $name => $plugin) {
             if (!$plugin->is_enabled()) {
@@ -54,7 +76,7 @@ class cltr extends \core\plugininfo\base {
     public static function get_ready_plugin_names() {
         $names = [];
 
-        $plugins = self::get_enabled_plugins();
+        $plugins = self::get_enabled_plugin_instances();
         foreach ($plugins as $plugin) {
             $collector = $plugin->get_collector();
             if ($collector->is_ready() && !in_array($plugin->name, $names)) {

--- a/tests/tool_cloudmetrics_lib_test.php
+++ b/tests/tool_cloudmetrics_lib_test.php
@@ -27,6 +27,43 @@ namespace tool_cloudmetrics;
 class tool_cloudmetrics_lib_test  extends \advanced_testcase {
 
     /**
+     * Tests cltr::get_enabled_plugins() that should return
+     * the plugin names as $pluginname => $pluginname.
+     *
+     * @throws \Exception
+     */
+    public function test_get_enabled_plugins() {
+        $pluginnames = \core_plugin_manager::instance()->get_enabled_plugins('cltr');
+        // Not all versions support assertIsArray(), use assertTrue() instead.
+        $this->assertTrue(is_array($pluginnames));
+        // If plugin is not enabled the result will be an empty array.
+        if (!empty($pluginnames)) {
+            foreach ($pluginnames as $key => $val) {
+                $this->assertRegExp('/^[a-z]+[a-z0-9_]*$/', $key);
+                $this->assertSame($key, $val);
+            }
+        }
+    }
+
+    /**
+     * Tests cltr::get_enabled_plugin_instances() that should return
+     * the plugin objects.
+     *
+     * @throws \Exception
+     */
+    public function test_get_enabled_plugin_instances() {
+        $plugins = plugininfo\cltr::get_enabled_plugin_instances();
+        // Not all versions support assertIsArray(), use assertTrue() instead.
+        $this->assertTrue(is_array($plugins));
+        // If plugin is not enabled the result will be an empty array.
+        if (!empty($plugins)) {
+            foreach ($plugins as $key => $val) {
+                $this->assertTrue(is_object($val));
+            }
+        }
+    }
+
+    /**
      * Tests lib::get_previous_time()
      *
      * @dataProvider data_for_get_previous_time

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022060700;
-$plugin->release = 2022060700;
+$plugin->version = 2022071500;
+$plugin->release = 2022071500;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
The function get_enabled_plugins() is used by the plugin manager to return the plugin names as an array containing $pluginname => $pluginname.For this reason the getting plugin instances is moved in a separate function.
Add unit tests to test cltr::get_enabled_plugins() and cltr::get_enabled_plugin_instances().

The error message and instructions to repeat can be found in the description of Issue #106.
After applying the fix, the existing test passes successfully:

```
root@a98befdc0147:/var/www/macquarie# vendor/bin/phpunit "core_plugin_manager_testcase" lib/tests/plugin_manager_test.php 
Moodle 3.9.14+ (Build: 20220701), 1b0ca9c4ded8c25141a6a62b728323800ca036c8
Php: 7.4.29, pgsql: 9.6.24, OS: Linux 5.15.0-37-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

.........................................                         41 / 41 (100%)

Time: 6.89 seconds, Memory: 93.00 MB

OK (41 tests, 6620 assertions)
```
The new tests added to `tool_cloudmetrics_lib_test`:
```
root@a98befdc0147:/var/www/macquarie# vendor/bin/phpunit --filter '/tool_cloudmetrics_lib_test/'
Moodle 3.9.14+ (Build: 20220701), 1b0ca9c4ded8c25141a6a62b728323800ca036c8
Php: 7.4.29, pgsql: 9.6.24, OS: Linux 5.15.0-37-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

...................................                               35 / 35 (100%)

Time: 25.73 seconds, Memory: 738.00 MB

OK (35 tests, 38 assertions)
```
