### PR TITLE
Issue #124: Remove output from PHP unit tests.

### DIFF
--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -128,7 +128,9 @@ class tool_cloudmetrics_collect_metrics_test extends \advanced_testcase {
             ->with($expected);
         $task = new helper_collect_metrics_task($mock);
         $task->set_time($time);
+        ob_start();
         $task->execute();
+        ob_end_clean();
     }
 
     /**

--- a/tests/tool_cloudmetrics_lib_test.php
+++ b/tests/tool_cloudmetrics_lib_test.php
@@ -39,7 +39,11 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
         // If plugin is not enabled the result will be an empty array.
         if (!empty($pluginnames)) {
             foreach ($pluginnames as $key => $val) {
-                $this->assertRegExp('/^[a-z]+[a-z0-9_]*$/', $key);
+                if (method_exists($this, 'assertMatchesRegularExpression')) {
+                    $this->assertMatchesRegularExpression('/^[a-z]+[a-z0-9_]*$/', $key);
+                } else {
+                    $this->assertRegExp('/^[a-z]+[a-z0-9_]*$/', $key);
+                }
                 $this->assertSame($key, $val);
             }
         }


### PR DESCRIPTION
Resolves #124 

Capture output with ob_start.
Update use of assertRegExp.