### PR TITLE
Issue #155: use of db api cast fix

### DIFF
--- a/collector/database/classes/collector.php
+++ b/collector/database/classes/collector.php
@@ -143,7 +143,7 @@ class collector extends base {
         } else {
             $metricselect = '';
             foreach ($params as $param) {
-                $metricselect .= "AVG(CASE name WHEN '$param' THEN CAST(value AS INT) END) $param,";
+                $metricselect .= "AVG(CASE name WHEN '$param' THEN" . $DB->sql_cast_char2int('value', true) . "END) $param,";
             }
             $metricselect = rtrim($metricselect, ',');
             $sql = "SELECT $incrementstart,


### PR DESCRIPTION
Hi @petersistrom,

This is a PR for issue #155, when selecting more than one metric using mysql will throw an error because of a hard coded cast.

Regards,

Marc