### PR TITLE
Issue #166: Fix callback to pick up custom metrics from third party plugins

### DIFF
--- a/classes/metric/manager.php
+++ b/classes/metric/manager.php
@@ -102,7 +102,7 @@ class manager {
         ];
 
         // Find metrics from plugins.
-        $more = get_plugins_with_function('_metrics', 'lib.php');
+        $more = get_plugins_with_function('metrics', 'lib.php');
         foreach ($more as $plugins) {
             foreach ($plugins as $pluginfunction) {
                 $result = $pluginfunction();


### PR DESCRIPTION
This fix will allow the `tool_cloudmetrics` to recognised custom metrics from third party plugins where a function with the suffix metrics is declared inside the` lib.php` file.