### PR TITLE
Issue #169: Update unit test  to disable custom metrics.

### DIFF
--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -138,8 +138,10 @@ class tool_cloudmetrics_collect_metrics_test extends \advanced_testcase {
 
     /**
      * This method gets all metrics (except those in sent in the data provider) and sets them into a disable state.
+     * @param array $expected The expected metrics.
+     *
      */
-    private function disable_metrics(array $expected): void {
+    private function disable_metrics(array $expected) {
         $metrics = metric\manager::get_metrics(true);
 
         foreach ($metrics as $metric) {

--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -126,11 +126,30 @@ class tool_cloudmetrics_collect_metrics_test extends \advanced_testcase {
         $mock->expects($this->once())
             ->method('receive')
             ->with($expected);
+
+        $this->disable_custom_metrics();
         $task = new helper_collect_metrics_task($mock);
         $task->set_time($time);
         ob_start();
         $task->execute();
         ob_end_clean();
+    }
+
+    /**
+     * This method gets all metrics available and disable those out of the builtin metrics.
+     *
+     * @return void
+     */
+    private function disable_custom_metrics(): void {
+        // Get builtin metrics from default setting frequency.
+        $builtinmetrics = array_keys(manager::FREQ_DEFAULTS);
+        $metrics = metric\manager::get_metrics(true);
+
+        foreach ($metrics as $metric) {
+            if (!in_array($metric->get_name(), $builtinmetrics)) {
+                $metric->set_enabled(false);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
- Since all metrics are enabled by default and data provider was supplied with builtin metrics only, we need to disable those custom metrics before the schedule task is executed.