### PR TITLE
Remove unnecessary dynamic properties #174

### DIFF
--- a/classes/check/collectorcheck.php
+++ b/classes/check/collectorcheck.php
@@ -32,14 +32,6 @@ use tool_cloudmetrics\plugininfo\cltr;
 class collectorcheck extends check {
 
     /**
-     * Constructor
-     */
-    public function __construct() {
-        $this->id = 'checkcollectorcheck';
-        $this->name = get_string('checkcollectorcheck', 'tool_cloudmetrics');
-    }
-
-    /**
      * A link to a place to action this
      *
      * @return action_link|null

--- a/classes/check/metriccheck.php
+++ b/classes/check/metriccheck.php
@@ -42,8 +42,6 @@ class metriccheck extends check {
      */
     public function __construct($metric) {
         $this->metric = $metric;
-        $this->id = $metric->get_name();
-        $this->name = $metric->get_label();
     }
 
     /**
@@ -52,7 +50,7 @@ class metriccheck extends check {
      * @return string must be unique within a component
      */
     public function get_id(): string {
-        return $this->id;
+        return $this->metric->get_name();
     }
 
     /**


### PR DESCRIPTION
PHP 8.2+ deprecation of dynamic properties.

$this->id and $this->name are references to old properties of check that were removed shortly after being added in MDL-67818, so these aren't being called from anywhere else and can be safely removed.

Closes #174 