### PR TITLE
[#178] Resolve dynamic property

### DIFF
--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -58,6 +58,9 @@ class mock_receiver {
  */
 class helper_collect_metrics_task extends collect_metrics_task {
 
+    /** @var mock_receiver Mock receiver */
+    private $mock;
+
     /**
      * Constructer for helper_collect_metrics_task
      *


### PR DESCRIPTION
Closes #178 

Unit tests now no longer output deprecation, and all remain passing.