### PR TITLE
[#194] Fix sql syntax for mssql

### DIFF
--- a/classes/metric/online_users_metric.php
+++ b/classes/metric/online_users_metric.php
@@ -106,13 +106,17 @@ class online_users_metric extends builtin_user_base {
         ];
 
         $interval = $secondsinterval[$frequency];
-        $sql = 'SELECT floor(timecreated / :interval ) * :intervaldup AS time,
-                       COUNT(DISTINCT userid) as value
-                  FROM {logstore_standard_log}
-                 WHERE timecreated >= :starttime
-                   AND timecreated <= :finishtime
-              GROUP BY 1
-              ORDER BY 1 ASC';
+        $sql = 'WITH user_data AS (
+                  SELECT floor(timecreated / :interval ) * :intervaldup AS time, userid
+                    FROM {logstore_standard_log}
+                   WHERE timecreated >= :starttime
+                     AND timecreated <= :finishtime
+                )
+
+                SELECT user_data.time as time, COUNT(DISTINCT(user_data.userid)) as value
+                  FROM user_data
+              GROUP BY user_data.time
+              ORDER BY user_data.time ASC';
         $rs = $DB->get_recordset_sql($sql,
                 ['interval' => $interval, 'intervaldup' => $interval, 'starttime' => $starttime, 'finishtime' => $finishtime]);
         $metricitems = [];


### PR DESCRIPTION
Closes #194 

## Changes
Fixes a few sql compatibility issues, namely:

- Group by [num] not supported in mssql, replaced with name of column
- Group by cannot work on field aliases, so in this case it has to be done after the expression for time is evaluated. So it has to be moved into a CTE

## Testing
- Local mssql unit tests, passing
- pgsql/mysql - Github CI