### PR TITLE
 Convert generate_metric_items to be an iterator #190

### DIFF
--- a/classes/collector/manager.php
+++ b/classes/collector/manager.php
@@ -100,31 +100,4 @@ class manager {
             }
         }
     }
-
-    /**
-     * Backfill an array of metrics to all backfillable collectors.
-     *
-     * @param array $items An array of metric_item.
-     */
-    public static function backfill_metrics(array $items) {
-        $plugins = cltr::get_enabled_plugin_instances();
-        if (!$plugins) {
-            mtrace('No collectors to send metrics to!');
-            return;
-        }
-        if (!$items) {
-            mtrace('No metrics to send at the moment');
-            return;
-        }
-        foreach ($plugins as $plugin) {
-            $collector = $plugin->get_collector();
-            if (!$collector->supports_backfillable_metrics()) {
-                mtrace("The '{$plugin->name}' collector does not support backfillable metrics");
-                return;
-            } else {
-                $collector->record_metrics($items);
-                mtrace("Recorded " . count($items) . " metrics to '{$plugin->name}' collector");
-            }
-        }
-    }
 }

--- a/classes/metric/base.php
+++ b/classes/metric/base.php
@@ -212,15 +212,25 @@ abstract class base {
     }
 
     /**
+     * Whether backfilled data should be sent to the collector incrementally.
+     * Slow queries should make use of this to persist metrics as they are calculated.
+     *
+     * @return bool
+     */
+    public function is_backfill_incremental(): bool {
+        return false;
+    }
+
+    /**
      * Returns records for backfilled metric.
      *
      * @param int $backwardperiod Time from which sample is to be retrieved.
      * @param int $finishtime If data is being completed argument is passed here.
      *
-     * @return array|null
+     * @return \Iterator
      */
-    public function generate_metric_items(int $backwardperiod, int $finishtime = null): ?array {
-        return null;
+    public function generate_metric_items(int $backwardperiod, int $finishtime = null): \Iterator {
+        return new \EmptyIterator();
     }
 
     /**

--- a/classes/metric/online_users_metric.php
+++ b/classes/metric/online_users_metric.php
@@ -76,9 +76,9 @@ class online_users_metric extends builtin_user_base {
      * @param int $finishtime If data is being completed argument is passed here.
      * @param \progress_bar|null $progress
      *
-     * @return array
+     * @return \Iterator
      */
-    public function generate_metric_items($backwardperiod, $finishtime = null, ?\progress_bar $progress = null): array {
+    public function generate_metric_items($backwardperiod, $finishtime = null, ?\progress_bar $progress = null): \Iterator {
         global $DB;
 
         // Get start time from period selection.
@@ -90,7 +90,7 @@ class online_users_metric extends builtin_user_base {
         [$mintmptmp, $maxtmpstmp, $freqretrieved] = $this->get_range_retrieved();
 
         if ($finishtime < $starttime) {
-            return [];
+            return new \EmptyIterator();
         }
         $secondsinterval = [
             manager::FREQ_MIN => MINSECS,
@@ -117,38 +117,39 @@ class online_users_metric extends builtin_user_base {
                 SELECT user_data.time as time, COUNT(DISTINCT(user_data.userid)) as value
                   FROM user_data
               GROUP BY user_data.time
-              ORDER BY user_data.time ASC";
+              ORDER BY user_data.time DESC";
         $rs = $DB->get_recordset_sql($sql,
                 ['interval' => $interval, 'intervaldup' => $interval, 'starttime' => $starttime, 'finishtime' => $finishtime]);
-        $metricitems = [];
+
+        $this->interval = $frequency;
         $count = 0;
         foreach ($rs as $r) {
-            if ($count !== 0 && $metricitems[$count - 1]->time + $interval !== (int)$r->time) {
+            $time = (int)$r->time;
+            if (!isset($this->maxtimestamp)) {
+                $this->maxtimestamp = $time;
+            }
+
+            if (isset($this->mintimestamp) && $this->mintimestamp - $interval !== $time) {
                 // Code to add times where no user have been concurrently active.
-                for ($i = $metricitems[$count - 1]->time + $interval; $i <= $r->time; $i += $interval) {
-                    if ($i === (int)$r->time) {
-                        $metricitems[] = new metric_item($this->get_name(), $r->time, $r->value, $this);
+                for ($i = $this->mintimestamp - $interval; $i >= $time; $i -= $interval) {
+                    if ($i === $time) {
+                        yield new metric_item($this->get_name(), $time, $r->value, $this);
                     } else {
-                        $metricitems[] = new metric_item($this->get_name(), $i, 0, $this);
+                        yield new metric_item($this->get_name(), $i, 0, $this);
                         $count++;
                     }
                 }
             } else {
-                $metricitems[] = new metric_item($this->get_name(), $r->time, $r->value, $this);
+                yield new metric_item($this->get_name(), $r->time, $r->value, $this);
             }
             if ($progress) {
                 $progress->update($count, $backwardperiod / $interval,
                     get_string('backfillgenerating', 'tool_cloudmetrics', $this->get_label()));
             }
             $count++;
+            $this->mintimestamp = $time;
         }
         $rs->close();
-
-        $this->mintimestamp = !empty($metricitems) ? $metricitems[0]->time : null;
-        $this->maxtimestamp = !empty($metricitems) ? end($metricitems)->time : null;
-        $this->interval = $frequency;
-
-        return $metricitems;
 
     }
 

--- a/classes/metric/yearly_active_users_metric.php
+++ b/classes/metric/yearly_active_users_metric.php
@@ -105,6 +105,17 @@ class yearly_active_users_metric extends builtin_user_base {
     public function is_autobackfill(): bool {
         return true;
     }
+
+    /**
+     * Whether backfilled data should be sent to the collector incrementally.
+     * Slow queries should make use of this to persist metrics as they are calculated.
+     *
+     * @return bool
+     */
+    public function is_backfill_incremental(): bool {
+        return true;
+    }
+
     /**
      * Generates the metric items from the source data.
      *
@@ -132,37 +143,45 @@ class yearly_active_users_metric extends builtin_user_base {
      * @param int|null $finishtime If data is being completed argument is passed here.
      * @param progress_bar|null $progress
      *
-     * @return array
+     * @return \Iterator
      */
-    public function generate_metric_items(int $backwardperiod, ?int $finishtime = null, ?progress_bar $progress = null): array {
+    public function generate_metric_items(int $backwardperiod, ?int $finishtime = null, ?progress_bar $progress = null): \Iterator {
         global $DB;
-        $metricitems = [];
+
         $finishtime = ($finishtime === -1) ? null : $finishtime;
         $finishtime = $finishtime ?? time();
         $starttime = $finishtime - $backwardperiod;
         // Get aggregation interval.
         $frequency = $this->get_frequency();
         $interval = lib::FREQ_TIMES[$frequency];
+
         if ($finishtime < $starttime) {
-            return [];
+            return new \EmptyIterator();
         }
+
+        $this->maxtimestamp = $finishtime;
+        $this->interval = $frequency;
+
         $sql = "SELECT COUNT(DISTINCT userid)
                   FROM {logstore_standard_log}
                  WHERE timecreated >= :from
                    AND timecreated <= :to
                    AND action = 'loggedin'";
+
         // Variables for updating progress.
         $count = 0;
+        $time = $finishtime;
         $total = ($finishtime - $starttime) / $interval;
-        // Build a metric for each day from starttime to finishtime.
-        while ($starttime <= $finishtime) {
-            $lastyear = $starttime - YEARSECS;
+        // Build a metric for each day from finishtime to starttime, processing the newest first.
+        while ($time >= $starttime) {
+            $lastyear = $time - YEARSECS;
             $activeusers = $DB->count_records_sql(
                 $sql,
-                ['from' => $lastyear, 'to' => $starttime]
+                ['from' => $lastyear, 'to' => $time]
             );
-            $metricitems[] = new metric_item($this->get_name(), $starttime, $activeusers, $this);
-            $starttime = $starttime + $interval;
+            $this->mintimestamp = $time;
+            yield new metric_item($this->get_name(), $time, $activeusers, $this);
+            $time -= $interval;
             $count++;
             if ($progress) {
                 $progress->update(
@@ -172,10 +191,6 @@ class yearly_active_users_metric extends builtin_user_base {
                 );
             }
         }
-        $this->mintimestamp = !empty($metricitems) ? $metricitems[0]->time : null;
-        $this->maxtimestamp = !empty($metricitems) ? end($metricitems)->time : null;
-        $this->interval = $frequency;
-        return $metricitems;
     }
 
     /**

--- a/classes/task/autobackfill_metrics_task.php
+++ b/classes/task/autobackfill_metrics_task.php
@@ -16,8 +16,8 @@
 
 namespace tool_cloudmetrics\task;
 
-use tool_cloudmetrics\collector;
 use tool_cloudmetrics\metric;
+use tool_cloudmetrics\plugininfo\cltr;
 
 /**
  * Auto back fills all data for each metric automatically everytime plugin installed or upgraded.
@@ -29,6 +29,9 @@ use tool_cloudmetrics\metric;
  */
 class autobackfill_metrics_task extends \core\task\adhoc_task {
 
+    /** @var array Enabled plugins */
+    private array $plugins;
+
     /**
      * Get task name
      */
@@ -39,18 +42,52 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
     /**
      * Will backfill the metrics using collectors.
      *
-     * @param array $items
+     * @param \tool_cloudmetrics\metric\base $metricclass Class representing metric.
+     * @param array $metricitems Array of metric items.
      */
-    public function backfill_metrics(array $items) {
-        collector\manager::backfill_metrics($items);
+    public function backfill_metrics(\tool_cloudmetrics\metric\base $metricclass, array $metricitems) {
+        if (!$metricitems) {
+            mtrace('No metrics to send at the moment');
+            return;
+        }
+        foreach ($this->plugins as $plugin) {
+            $collector = $plugin->get_collector();
+            if ($collector->supports_backfillable_metrics()) {
+                $collector->record_saved_metrics($metricclass, $metricitems);
+                mtrace(sprintf("Recorded %s '%s' metrics to %s", count($metricitems), $metricclass->get_name(), $plugin->name));
+            }
+        }
     }
+
     /**
      *  Execute task
      */
     public function execute() {
+        $this->plugins = cltr::get_enabled_plugin_instances();
+        if (!$this->plugins) {
+            mtrace('No collectors to send metrics to!');
+            return;
+        }
+
+        $customdata = $this->get_custom_data();
         $nowts = time();
-        $collectingperiod = YEARSECS;
+        $collectingperiod = $customdata->period ?? YEARSECS;
+        $autobackfill = !isset($customdata->metric);
         $metrictypes = metric\manager::get_metrics(true);
+
+        // Filter to a specific metric.
+        if (isset($customdata->metric)) {
+            $metric = $customdata->metric;
+            if (!array_key_exists($metric, $metrictypes)) {
+                mtrace("{$metric} is an invalid metric type");
+                return;
+            }
+
+            $metrictypes = [
+                $metric => $metrictypes[$metric],
+            ];
+        }
+
         $total = 0;
         foreach ($metrictypes as $metrictype) {
             if (!$metrictype->is_ready()) {
@@ -60,28 +97,51 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
                 mtrace("The '{$metrictype->get_name()}' metric does not support backfilling data");
                 continue;
             }
-            if (!$metrictype->is_autobackfill()) {
+            if ($autobackfill && !$metrictype->is_autobackfill()) {
                 mtrace("The '{$metrictype->get_name()}' metric does not support auto backfilling");
                 continue;
             }
+
+            $starttime = $nowts - $collectingperiod;
+            $finishtime = $nowts;
+
+            // Check if data has already been backfilled.
+            [$backfillmin, $backfillmax, $backfillinterval] = $metrictype->get_range_retrieved();
+            if ($backfillinterval === $metrictype->get_frequency() && $backfillmin > 0) {
+                // If a backfill range exists for this frequency, we only need to backfill older data.
+                $finishtime = $backfillmin;
+            }
+
+            if ($finishtime < $starttime) {
+                mtrace(sprintf(
+                    "The '%s' metric has already been backfilled to %s",
+                    $metrictype->get_name(),
+                    userdate($finishtime, '%e %b %Y, %H:%M')
+                ));
+                continue;
+            }
+
             mtrace(sprintf(
                 'Generating metrics for %s from %s to %s',
                 $metrictype->get_name(),
-                userdate($nowts, '%e %b %Y, %H:%M'),
-                userdate(($nowts - $collectingperiod), '%e %b %Y, %H:%M')
+                userdate($finishtime, '%e %b %Y, %H:%M'),
+                userdate($starttime, '%e %b %Y, %H:%M')
             ));
-            $metrics = $metrictype->generate_metric_items($collectingperiod, $nowts);
+
+            $metrics = $metrictype->generate_metric_items($collectingperiod, $finishtime);
             if ($metrictype->is_backfill_incremental()) {
                 // We have a slow query so want to send metrics to the collector immediately.
                 $count = 0;
                 foreach ($metrics as $metric) {
-                    $this->backfill_metrics([$metric]);
+                    $this->backfill_metrics($metrictype, [$metric]);
                     $count++;
                 }
             } else {
                 // Process the metrics as a batch.
                 $metrics = iterator_to_array($metrics);
-                $this->backfill_metrics($metrics);
+                if ($metrics) {
+                    $this->backfill_metrics($metrictype, $metrics);
+                }
                 $count = count($metrics);
             }
 

--- a/classes/task/autobackfill_metrics_task.php
+++ b/classes/task/autobackfill_metrics_task.php
@@ -70,10 +70,23 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
                 userdate($nowts, '%e %b %Y, %H:%M'),
                 userdate(($nowts - $collectingperiod), '%e %b %Y, %H:%M')
             ));
-            $items = $metrictype->generate_metric_items($collectingperiod, $nowts);
-            mtrace(sprintf('Generated %s %s metrics', count($items),  $metrictype->get_name()));
-            $this->backfill_metrics($items);
-            $total += count($items);
+            $metrics = $metrictype->generate_metric_items($collectingperiod, $nowts);
+            if ($metrictype->is_backfill_incremental()) {
+                // We have a slow query so want to send metrics to the collector immediately.
+                $count = 0;
+                foreach ($metrics as $metric) {
+                    $this->backfill_metrics([$metric]);
+                    $count++;
+                }
+            } else {
+                // Process the metrics as a batch.
+                $metrics = iterator_to_array($metrics);
+                $this->backfill_metrics($metrics);
+                $count = count($metrics);
+            }
+
+            mtrace(sprintf('Generated %s %s metrics', $count,  $metrictype->get_name()));
+            $total += $count;
         }
         mtrace('Backfilled totally '.$total.' metrics');
     }

--- a/collector/database/backfill.php
+++ b/collector/database/backfill.php
@@ -112,7 +112,7 @@ if ($fromform = $mform->get_data()) {
     $progressbar->create();
     $periodretrieval = $fromform->periodretrieval;
     $metricitems = $metrics[$metricname]->generate_metric_items($periodretrieval, $mintmptmp, $progressbar);
-    $collector->record_saved_metrics($metrics[$metricname], $metricitems, $progressbar);
+    $collector->record_saved_metrics($metrics[$metricname], iterator_to_array($metricitems), $progressbar);
     $progressbar->update_full(100, get_string('backfillcomplete', 'tool_cloudmetrics', $metrics[$metricname]->get_label()));
 }
 echo $OUTPUT->footer();

--- a/collector/database/backfill.php
+++ b/collector/database/backfill.php
@@ -23,7 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-define('NO_OUTPUT_BUFFERING', true);
 require_once(__DIR__.'/../../../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 
@@ -103,16 +102,19 @@ $context['metriclabel'] = $metrics[$metricname]->get_label();
 $context['isdifferentfreq'] = $isdifferentfreq ?? null;
 
 $renderer = $PAGE->get_renderer('tool_cloudmetrics');
-$progressbar = new progress_bar();
+
+if ($fromform = $mform->get_data()) {
+    $backfilltask = new \tool_cloudmetrics\task\autobackfill_metrics_task();
+    $backfilltask->set_custom_data([
+        'metric' => $metricname,
+        'period' => $fromform->periodretrieval,
+    ]);
+    \core\task\manager::queue_adhoc_task($backfilltask, true);
+
+    \core\notification::info(get_string('metrics_backfill_queued', 'cltr_database', $metricname));
+    redirect($tochart);
+}
 
 echo $OUTPUT->header();
 echo $renderer->render_backfill_page($context);
-if ($fromform = $mform->get_data()) {
-    \core\session\manager::write_close(); // Unlock session while backfilling.
-    $progressbar->create();
-    $periodretrieval = $fromform->periodretrieval;
-    $metricitems = $metrics[$metricname]->generate_metric_items($periodretrieval, $mintmptmp, $progressbar);
-    $collector->record_saved_metrics($metrics[$metricname], iterator_to_array($metricitems), $progressbar);
-    $progressbar->update_full(100, get_string('backfillcomplete', 'tool_cloudmetrics', $metrics[$metricname]->get_label()));
-}
 echo $OUTPUT->footer();

--- a/collector/database/cli/fill_database.php
+++ b/collector/database/cli/fill_database.php
@@ -34,5 +34,6 @@ $metric = new \tool_cloudmetrics\metric\test_metric();
 $metric->name = 'activeusers';
 
 for ($x = 0; $x <= 100; ++$x) {
-    $collector->record_metrics($metric->generate_metric_items(0, 0));
+    $metrics = iterator_to_array($metric->generate_metric_items(0, 0));
+    $collector->record_metrics($metrics);
 }

--- a/collector/database/lang/en/cltr_database.php
+++ b/collector/database/lang/en/cltr_database.php
@@ -48,6 +48,7 @@ $string['select_group'] = 'Display metrics by group.';
 // Scheduled tasks.
 $string['metrics_cleanup_task'] = 'Cleanup metrics task';
 $string['metrics_autobackfill_task'] = 'Auto back-fill task';
+$string['metrics_backfill_queued'] = 'Backfill adhoc task queued for {$a}.';
 
 // Time format.
 $string['strftimedatetime'] = '%d %h %Y, %H:%M';

--- a/collector/database/tests/cltr_database_test.php
+++ b/collector/database/tests/cltr_database_test.php
@@ -202,7 +202,8 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
         $DB->insert_records('logstore_standard_log', $dataobjects);
         $rec = $DB->get_records('logstore_standard_log');
         $this->assertEquals(100, count($rec));
-        $collector->record_saved_metrics($onlinemetric, $onlinemetric->generate_metric_items(1590465600, 1590580800));
+        $metrics = iterator_to_array($onlinemetric->generate_metric_items(1590465600, 1590580800));
+        $collector->record_saved_metrics($onlinemetric, $metrics);
         $rec = $DB->get_records(lib::TABLE);
         $count = 0;
         foreach ($rec as $r) {

--- a/db/install.php
+++ b/db/install.php
@@ -31,5 +31,5 @@ function xmldb_tool_cloudmetrics_install() {
         return;
     }
     $backfilltask = new \tool_cloudmetrics\task\autobackfill_metrics_task();
-    \core\task\manager::queue_adhoc_task($backfilltask);
+    \core\task\manager::queue_adhoc_task($backfilltask, true);
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -74,7 +74,7 @@ function xmldb_tool_cloudmetrics_upgrade($oldversion) {
 
     if ($oldversion < 2025072300) {
         $backfilltask = new \tool_cloudmetrics\task\autobackfill_metrics_task();
-        \core\task\manager::queue_adhoc_task($backfilltask);
+        \core\task\manager::queue_adhoc_task($backfilltask, true);
         upgrade_plugin_savepoint(true, 2025072300, 'tool', 'cloudmetrics');
     }
     return true;

--- a/tests/tool_cloudmetrics_online_users_metric_test.php
+++ b/tests/tool_cloudmetrics_online_users_metric_test.php
@@ -77,11 +77,11 @@ final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcas
         // Get metrics with finish time less than start time. Should be empty.
         $backperiod = 86400;
         $finish = time() - 17200;
-        $metrics = $onlinemetric->generate_metric_items($backperiod, $finish);
+        $metrics = iterator_to_array($onlinemetric->generate_metric_items($backperiod, $finish));
         $this->assertEmpty($metrics);
 
         // Get metrics for previous 24 hr period. Should be empty.
-        $metrics = $onlinemetric->generate_metric_items($backperiod);
+        $metrics = iterator_to_array($onlinemetric->generate_metric_items($backperiod));
         $this->assertEmpty($metrics);
 
         // Frequency periods.
@@ -90,14 +90,14 @@ final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcas
 
         // Get metrics for previous year with frequency 60 seconds.
         $onlinemetric->set_frequency(1);
-        $metrics = $onlinemetric->generate_metric_items(31556926);
-        $count = (end($metrics)->time - $metrics[0]->time) / $freq1 + 1;
+        $metrics = iterator_to_array($onlinemetric->generate_metric_items(31556926));
+        $count = ($metrics[0]->time - end($metrics)->time) / $freq1 + 1;
         $this->assertCount($count, $metrics);
 
         // Get metrics for previous year with frequency 300 seconds.
         $onlinemetric->set_frequency(2);
-        $metrics = $onlinemetric->generate_metric_items(31556926);
-        $count = (end($metrics)->time - $metrics[0]->time) / $freq2 + 1;
+        $metrics = iterator_to_array($onlinemetric->generate_metric_items(31556926));
+        $count = ($metrics[0]->time - end($metrics)->time) / $freq2 + 1;
         $this->assertCount($count, $metrics);
     }
 }


### PR DESCRIPTION
We've noticed a few issues where the backfill task was failing partway and nothing was being saved, causing the entire task to be restarted and in some cases this was being looped.

To address this I've:
- Converted generate_metric_items to an iterator. Some backfills are faster and may only want to save data at the end so I've made this optional with is_backfill_incremental() on the metric. 
- Reordered generate_metric_items functions to start processing at the finishtime and work backwards, so that the partially saved data matches the correct range.
- Copied the backfill logic from the UI to track which ranges which have already been backfilled and start from there.
- Updated backfill in the UI to use the task so we don't have 2 ways of doing the same thing.

In my testing the logic for get_range_retrieved which stores backfilled data ranges isn't polished, so it may need some further testing / improvements / unit tests. Note that saving the ranges was missing from the task originally as it was saved differently, so with the current logic those backfilled ranges are missing. This means that auto backfilling may happen a second time upon upgrading from the 3.5 branch to 4.4 branch if it was ran before these changes are merged in (this would also happen with the current logic).

Closes #190 