### PR TITLE
Fix yearly active users metric starttime when resuming

### DIFF
--- a/classes/metric/yearly_active_users_metric.php
+++ b/classes/metric/yearly_active_users_metric.php
@@ -150,7 +150,7 @@ class yearly_active_users_metric extends builtin_user_base {
 
         $finishtime = ($finishtime === -1) ? null : $finishtime;
         $finishtime = $finishtime ?? time();
-        $starttime = $finishtime - $backwardperiod;
+        $starttime = time() - $backwardperiod;
         // Get aggregation interval.
         $frequency = $this->get_frequency();
         $interval = lib::FREQ_TIMES[$frequency];


### PR DESCRIPTION
Fix for #201 

If the backfill task for yearly active users metric fails partway through, it resumes at the correct point but backfills further than the intended backwardperiod. This fixes starttime, which is used to calculate the end point. 