### PR TITLE
Fix: resolve PHPUnit 11 test failures occuring in Moodle 500+ (closes #204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In general a metric is any real time value that you might push to another servic
 
 | Moodle version   | Branch            | PHP  |
 |------------------|-------------------|------|
+| Moodle 5.0+      | MOODLE_500_STABLE | 8.2+ |
 | Moodle 4.4+      | MOODLE_404_STABLE | 8.1+ |
 | Moodle 3.5 - 4.3 | MOODLE_35_STABLE  | 7.1+ |
 | Totara 10+       | MOODLE_35_STABLE  | 7.1+ |

--- a/classes/collector/base.php
+++ b/classes/collector/base.php
@@ -43,7 +43,7 @@ abstract class base {
      * @param \progress_bar|null $progress
      * @return mixed
      */
-    public function record_metrics(array $metrics, \progress_bar $progress = null) {
+    public function record_metrics(array $metrics, ?\progress_bar $progress = null) {
         $count = 0;
         foreach ($metrics as $metric) {
             $this->record_metric($metric);

--- a/classes/metric/base.php
+++ b/classes/metric/base.php
@@ -225,11 +225,11 @@ abstract class base {
      * Returns records for backfilled metric.
      *
      * @param int $backwardperiod Time from which sample is to be retrieved.
-     * @param int $finishtime If data is being completed argument is passed here.
+     * @param int|null $finishtime If data is being completed argument is passed here.
      *
      * @return \Iterator
      */
-    public function generate_metric_items(int $backwardperiod, int $finishtime = null): \Iterator {
+    public function generate_metric_items(int $backwardperiod, ?int $finishtime = null): \Iterator {
         return new \EmptyIterator();
     }
 

--- a/collector/database/classes/collector.php
+++ b/collector/database/classes/collector.php
@@ -163,7 +163,7 @@ class collector extends base {
      * @param array $metricitems Array of metric items.
      * @param \progress_bar|null $progress
      */
-    public function record_saved_metrics(\tool_cloudmetrics\metric\base $metricclass, array $metricitems = [], \progress_bar $progress = null) {
+    public function record_saved_metrics(\tool_cloudmetrics\metric\base $metricclass, array $metricitems = [], ?\progress_bar $progress = null) {
         global $DB;
         $transaction = $DB->start_delegated_transaction();
         if (count($metricitems) != 0 && !$metricclass->sameconfig) {

--- a/collector/database/tests/cltr_database_test.php
+++ b/collector/database/tests/cltr_database_test.php
@@ -20,6 +20,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . "/../../../tests/metric_testcase.php"); // This is needed. File will not be automatically included.
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use tool_cloudmetrics\metric\manager;
 use tool_cloudmetrics\metric\online_users_metric;
 use tool_cloudmetrics\metric\active_users_metric;
@@ -32,6 +35,13 @@ use tool_cloudmetrics\metric\active_users_metric;
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+#[
+    CoversClass(\cltr_database\collector::class),
+    CoversMethod(\cltr_database\collector::class, 'record_saved_metrics'),
+    CoversMethod(\cltr_database\lib::class, 'get_midnight_of'),
+    CoversMethod(\cltr_database\lib::class, 'period_from_interval'),
+    CoversClass(\cltr_database\task\metrics_cleanup_task::class),
+]
 class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
 
     /** @var int Hours in a day*/
@@ -50,11 +60,10 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Test get_midnight_of.
      *
-     * @dataProvider midnight_provider
-     * @covers \cltr_database\lib::get_midnight_of
      * @param string $datestr
      * @param string  $expected   The expected result of the transformation
      */
+    #[DataProvider('midnight_provider')]
     public function test_midnight(string $datestr, string $expected) {
         $tz = \core_date::get_server_timezone_object();
         $time = lib::get_midnight_of($datestr, $tz);
@@ -69,7 +78,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return \string[][]
      */
-    public function midnight_provider(): array {
+    public static function midnight_provider(): array {
         return [
             ['today -5 hours', 'yesterday'],
             ['today +20 hours', 'today'],
@@ -86,11 +95,10 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Tests get_midnight_of's ability to handle timestamps.
      *
-     * @dataProvider midnight_provider
-     * @covers \cltr_database\lib::get_midnight_of
      * @param string $datestr
      * @param string $expected
      */
+    #[DataProvider('midnight_provider')]
     public function test_midnight_timestamp(string $datestr, string $expected) {
         $tz = \core_date::get_server_timezone_object();
         $ti = new \DateTimeImmutable($datestr, $tz);
@@ -103,7 +111,6 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Tests the database collector
      *
-     * @covers \cltr_database\collector
      */
     public function test_collector() {
         global $DB;
@@ -157,7 +164,6 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Test backfillable metric, here the 'active' metric.
      *
-     * @covers \cltr_database\collector::record_saved_metrics
      */
     public function test_backfillable_metric() {
         global $DB;
@@ -218,8 +224,6 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Test expiry metric_expiry task is working properly
      *
-     * @dataProvider expiry_provider
-     * @covers \cltr_database\task\metrics_cleanup_task
      * @param int $daysago
      * @param int $houradjustment
      * @param int $expiry
@@ -227,6 +231,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      * @param int $numexpected
      * @throws \dml_exception
      */
+    #[DataProvider('expiry_provider')]
     public function test_expiry(int $daysago, int $houradjustment, int $expiry, int $numrecords, int $numexpected) {
         global $DB;
 
@@ -275,7 +280,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return array
      */
-    public function expiry_provider(): array {
+    public static function expiry_provider(): array {
         return [
             [20, 10, 10 * DAYSECS, 20, 10],
             [20, -2, 10 * DAYSECS, 20, 9],
@@ -286,11 +291,10 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /**
      * Tests lib::period_from_inerval().
      *
-     * @dataProvider period_from_interval_provider
-     * @covers \cltr_database\lib::period_from_interval
      * @param int $freq
      * @param int $expected
      */
+    #[DataProvider('period_from_interval_provider')]
     public function test_period_from_interval(int $freq, int $expected) {
         $metric = new \tool_cloudmetrics\metric\online_users_metric();
         $metric->set_frequency($freq);
@@ -302,7 +306,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return array[]
      */
-    public function period_from_interval_provider(): array {
+    public static function period_from_interval_provider(): array {
         return [
             [ manager::FREQ_MIN, DAYSECS * 7],
             [ manager::FREQ_5MIN, DAYSECS * 7],

--- a/tests/tool_cloudmetrics_collect_metrics_test.php
+++ b/tests/tool_cloudmetrics_collect_metrics_test.php
@@ -27,6 +27,7 @@ namespace tool_cloudmetrics;
 
 use DateTime;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use tool_cloudmetrics\metric\manager;
 use tool_cloudmetrics\task\collect_metrics_task;
 
@@ -105,13 +106,13 @@ class tool_cloudmetrics_collect_metrics_test extends \advanced_testcase {
     /**
      * Test the execute method.
      *
-     * @dataProvider execute_provider
      * @param string $timestr The 'current' time to be used.
      * @param array $meta List of [<frequency>, <last_generate_time>].
      * @param array $expected The metrics that are expected to be in the result set.
      * @covers \tool_cloudmetrics\task\collect_metrics_task
      * @throws Exception
      */
+    #[DataProvider('execute_provider')]
     public function test_execute(string $timestr, array $meta, array $expected): void {
         $tz = \core_date::get_server_timezone_object();
         $this->disable_metrics($expected);

--- a/tests/tool_cloudmetrics_lib_test.php
+++ b/tests/tool_cloudmetrics_lib_test.php
@@ -16,6 +16,8 @@
 
 namespace tool_cloudmetrics;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * Unit tests for lib class.
  *
@@ -70,12 +72,12 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
     /**
      * Tests lib::get_previous_time()
      *
-     * @dataProvider data_for_get_previous_time
      * @param string $ref
      * @param int $freq
      * @param string $expected
      * @throws \Exception
      */
+    #[DataProvider('data_for_get_previous_time')]
     public function test_get_previous_time(string $ref, int $freq, string $expected) {
         $tz = \core_date::get_server_timezone_object();
 
@@ -90,7 +92,7 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function data_for_get_previous_time(): array {
+    public static function data_for_get_previous_time(): array {
         return [
             ['10:05',  metric\manager::FREQ_MIN, '10:04'],
             ['10:07',  metric\manager::FREQ_5MIN, '10:02'],
@@ -108,12 +110,12 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
     /**
      * Tests lib::get_next_time()
      *
-     * @dataProvider data_for_get_next_time
      * @param string $ref
      * @param int $freq
      * @param string $expected
      * @throws \Exception
      */
+    #[DataProvider('data_for_get_next_time')]
     public function test_get_next_time(string $ref, int $freq, string $expected) {
         $tz = \core_date::get_server_timezone_object();
 
@@ -128,7 +130,7 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function data_for_get_next_time(): array {
+    public static function data_for_get_next_time(): array {
         return [
             ['10:05',  metric\manager::FREQ_MIN, '10:06'],
             ['10:07',  metric\manager::FREQ_5MIN, '10:12'],
@@ -146,12 +148,12 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
     /**
      * Tests lib::get_next_time()
      *
-     * @dataProvider data_for_get_last_whole_tick
      * @param string $ref
      * @param int $freq
      * @param string $expected
      * @throws \Exception
      */
+    #[DataProvider('data_for_get_last_whole_tick')]
     public function test_get_last_whole_tick(string $ref, int $freq, string $expected) {
         $tz = \core_date::get_server_timezone_object();
 
@@ -166,7 +168,7 @@ class tool_cloudmetrics_lib_test  extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function data_for_get_last_whole_tick(): array {
+    public static function data_for_get_last_whole_tick(): array {
         return [
             ['10:06',  metric\manager::FREQ_MIN, '10:06'],
             ['10:07',  metric\manager::FREQ_5MIN, '10:05'],

--- a/tests/tool_cloudmetrics_online_users_metric_test.php
+++ b/tests/tool_cloudmetrics_online_users_metric_test.php
@@ -16,6 +16,7 @@
 
 namespace tool_cloudmetrics;
 
+use PHPUnit\Framework\Attributes\CoversMethod;
 use tool_cloudmetrics\metric\online_users_metric;
 
 /**
@@ -25,6 +26,7 @@ use tool_cloudmetrics\metric\online_users_metric;
  * @copyright 2025, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+#[CoversMethod(online_users_metric::class, 'generate_metric_items')]
 final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcase {
 
     /**
@@ -38,7 +40,6 @@ final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcas
     /**
      * Tests generate metric items
      *
-     * @covers \tool_cloudmetrics\metric\generate_metric_items
      */
     public function test_generate_metric_items(): void {
         global $DB;

--- a/tests/tool_cloudmetrics_users_test.php
+++ b/tests/tool_cloudmetrics_users_test.php
@@ -16,6 +16,7 @@
 
 namespace tool_cloudmetrics;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use tool_cloudmetrics\metric\metric_item;
 use tool_cloudmetrics\metric\new_users_metric;
 use tool_cloudmetrics\metric\active_users_metric;
@@ -73,12 +74,12 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
     /**
      * Tests generate_metric_items() for the builtin user metrics.
      *
-     * @dataProvider data_for_test_generate_metrics
      * @param string $metricname The name of the metric to be tested.
      * @param int $frequency The frequency setting as a metric\manager::FREQ_ value.
      * @param array $expected List of metric items that expect to be generated.
      * @throws \dml_exception
      */
+    #[DataProvider('data_for_test_generate_metrics')]
     public function test_generate_metrics(string $metricname, int $frequency, array $expected): void {
         global $DB;
 
@@ -106,11 +107,11 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
     /**
      * Tests test_generate_yearly_active_users_metric() for the builtin user metrics.
      *
-     * @dataProvider data_for_test_generate_yearly_active_users_metric
      * @param string $metricname The name of the metric to be tested.
      * @param array $expected List of metric items that expect to be generated.
      * @throws \dml_exception
      */
+    #[DataProvider('data_for_test_generate_yearly_active_users_metric')]
     public function test_generate_yearly_active_users_metric(string $metricname, array $expected): void {
         global $DB;
 
@@ -134,7 +135,7 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function data_for_test_generate_metrics(): array {
+    public static function data_for_test_generate_metrics(): array {
         $newusersmetric = new new_users_metric();
         $activeusersmetric = new active_users_metric();
         $onlineusersmetric = new online_users_metric();
@@ -171,7 +172,7 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function data_for_test_generate_yearly_active_users_metric(): array {
+    public static function data_for_test_generate_yearly_active_users_metric(): array {
         $yearlyactiveusers = new yearly_active_users_metric();
 
         return [

--- a/version.php
+++ b/version.php
@@ -25,12 +25,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025082000;
+$plugin->version = 2026011200;
 $plugin->release = 2025072301;
 
-$plugin->requires = 2024042200;    // Our lowest supported Moodle (4.4.0).
+$plugin->requires = 2025041400;    // Our lowest supported Moodle (5.0).
 
-$plugin->supported = [404, 405];     // Available as of Moodle 4.4.0 or later.
+$plugin->supported = [500, 501];     // Available as of Moodle 5.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.
 
 $plugin->component = 'tool_cloudmetrics';


### PR DESCRIPTION
### Summary
Updates the test suite for Moodle 500+ compatibility:
- Make data providers static.
- Update doc-comment metadata like `@dataProvider` and `@covers` with PHP 8 attributes replacements. 

- [ ] Update version file
- [ ] Fix Unit tests

### Scope
- Test code only
- No runtime or functional changes