### PR TITLE
Issue #207: Refactor backfill to be more stable

### DIFF
--- a/classes/collector/base.php
+++ b/classes/collector/base.php
@@ -27,7 +27,6 @@ use tool_cloudmetrics\metric\metric_item;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class base {
-
     /**
      * Records a single metric.
      *
@@ -43,13 +42,16 @@ abstract class base {
      * @param \progress_bar|null $progress
      * @return mixed
      */
-    public function record_metrics(array $metrics, \progress_bar $progress = null) {
+    public function record_metrics(array $metrics, ?\progress_bar $progress = null) {
         $count = 0;
         foreach ($metrics as $metric) {
             $this->record_metric($metric);
             if ($progress) {
-                $progress->update($count, count($metrics),
-                    get_string('backfillsaving', 'tool_cloudmetrics', $metric->name));
+                $progress->update(
+                    $count,
+                    count($metrics),
+                    get_string('backfillsaving', 'tool_cloudmetrics', $metric->name)
+                );
                 $count++;
             }
         }
@@ -80,6 +82,15 @@ abstract class base {
      * @return bool
      */
     public function is_auto_backfill(): bool {
+        return false;
+    }
+
+    /**
+     * Can we retrieve saved metrics from this collector?
+     *
+     * @return bool
+     */
+    public function is_readable(): bool {
         return false;
     }
 }

--- a/classes/collector/manager.php
+++ b/classes/collector/manager.php
@@ -16,8 +16,9 @@
 
 namespace tool_cloudmetrics\collector;
 
-use tool_cloudmetrics\metric\metric_item;
+use core\exception\moodle_exception;
 use tool_cloudmetrics\plugininfo\cltr;
+use tool_cloudmetrics\collector\base as collectorbase;
 
 /**
  * Manager class for collectors.
@@ -42,6 +43,22 @@ class manager {
     }
 
     /**
+     * Get an instance of a collector.
+     *
+     * @param $name
+     *
+     * @return \tool_cloudmetrics\collector\base
+     * @throws moodle_exception Thrown if collector is not installed.
+     */
+    public static function get_collector($name): collectorbase {
+        $classname = '\\cltr_' . $name . '\collector';
+        if (!class_exists($classname)) {
+            throw new moodle_exception('Class ' . $classname . ' does not exist');
+        }
+        return new $classname();
+    }
+
+    /**
      * Sends an array of metrics to all enabled collectors.
      *
      * @param array $items An array of metric_item.
@@ -61,7 +78,7 @@ class manager {
         foreach ($plugins as $plugin) {
             $collector = $plugin->get_collector();
 
-            // If the status is empty then we don't know. If it it positive then
+            // If the status is empty then we don't know. If it is positive then
             // it is a timestamp of when it originally failed. If it is negative
             // then it is a timestamp of when it originally worked.
             $key = self::STATUS_PREFIX . $plugin->name;

--- a/classes/lib.php
+++ b/classes/lib.php
@@ -34,11 +34,11 @@ class lib {
         manager::FREQ_5MIN => MINSECS * 5,
         manager::FREQ_15MIN => MINSECS * 15,
         manager::FREQ_30MIN => MINSECS * 30,
-        manager::FREQ_HOUR => MINSECS * 60,
-        manager::FREQ_3HOUR => MINSECS * 180,
-        manager::FREQ_12HOUR => MINSECS * 720,
-        manager::FREQ_DAY => MINSECS * 1440,
-        manager::FREQ_WEEK => MINSECS * 10080,
+        manager::FREQ_HOUR => HOURSECS,
+        manager::FREQ_3HOUR => HOURSECS * 3,
+        manager::FREQ_12HOUR => HOURSECS * 12,
+        manager::FREQ_DAY => DAYSECS,
+        manager::FREQ_WEEK => WEEKSECS,
     ];
 
     /**

--- a/classes/metric/manager.php
+++ b/classes/metric/manager.php
@@ -102,6 +102,10 @@ class manager {
             'dailyusers' => new daily_users_metric(),
             'yearlyactiveusers' => new yearly_active_users_metric(),
         ];
+        if (defined('PHPUNIT_TEST')) {
+            // Add testing metrics to the list.
+            $metrics['foobar'] = new test_metric();
+        }
 
         // Find metrics from plugins.
         $more = get_plugins_with_function('metrics', 'lib.php');

--- a/classes/metric/online_users_metric.php
+++ b/classes/metric/online_users_metric.php
@@ -29,18 +29,6 @@ class online_users_metric extends builtin_user_base {
     /** @var string The DB field the metric accesses. */
     protected $dbfield = 'lastaccess';
 
-    /** @var int The interval config for which data is displayed in seconds (eg: 5 minutes = 300). */
-    public $interval;
-
-    /** @var int The minimal timestamp representing earliest date retrieved in DB. */
-    public $mintimestamp;
-
-    /** @var int The maximal timestamp representing latest date retrieved in DB. */
-    public $maxtimestamp;
-
-    /** @var bool True if config used is same as one requested. */
-    public $sameconfig;
-
     /**
      * The metric's name.
      *
@@ -68,7 +56,6 @@ class online_users_metric extends builtin_user_base {
         return true;
     }
 
-
     /**
      * Returns records for backfilled metric.
      *
@@ -87,23 +74,12 @@ class online_users_metric extends builtin_user_base {
         // Allows data to be completed instead of retrieving all data again unless frequency change.
         $finishtime = $finishtime ?? time();
         $frequency = $this->get_frequency();
-        [$mintmptmp, $maxtmpstmp, $freqretrieved] = $this->get_range_retrieved();
 
         if ($finishtime < $starttime) {
             return new \EmptyIterator();
         }
-        $secondsinterval = [
-            manager::FREQ_MIN => MINSECS,
-            manager::FREQ_5MIN => MINSECS * 5,
-            manager::FREQ_15MIN => MINSECS * 15,
-            manager::FREQ_30MIN  => MINSECS * 30,
-            manager::FREQ_HOUR => HOURSECS,
-            manager::FREQ_3HOUR => HOURSECS * 3,
-            manager::FREQ_12HOUR => HOURSECS * 12,
-            manager::FREQ_DAY => DAYSECS,
-            manager::FREQ_WEEK => WEEKSECS,
-            manager::FREQ_MONTH => WEEKSECS * 4,
-        ];
+        $secondsinterval = \tool_cloudmetrics\lib::FREQ_TIMES;
+        $secondsinterval[manager::FREQ_MONTH] = WEEKSECS * 4; // Caution! This is 28 days.
 
         $interval = $secondsinterval[$frequency];
         $sql = "WITH user_data AS (
@@ -121,17 +97,16 @@ class online_users_metric extends builtin_user_base {
         $rs = $DB->get_recordset_sql($sql,
                 ['interval' => $interval, 'intervaldup' => $interval, 'starttime' => $starttime, 'finishtime' => $finishtime]);
 
-        $this->interval = $frequency;
         $count = 0;
         foreach ($rs as $r) {
             $time = (int)$r->time;
-            if (!isset($this->maxtimestamp)) {
-                $this->maxtimestamp = $time;
+            if (!isset($maxtimestamp)) {
+                $maxtimestamp = $time;
             }
 
-            if (isset($this->mintimestamp) && $this->mintimestamp - $interval !== $time) {
+            if (isset($mintimestamp) && $mintimestamp - $interval !== $time) {
                 // Code to add times where no user have been concurrently active.
-                for ($i = $this->mintimestamp - $interval; $i >= $time; $i -= $interval) {
+                for ($i = $mintimestamp - $interval; $i >= $time; $i -= $interval) {
                     if ($i === $time) {
                         yield new metric_item($this->get_name(), $time, $r->value, $this);
                     } else {
@@ -147,23 +122,8 @@ class online_users_metric extends builtin_user_base {
                     get_string('backfillgenerating', 'tool_cloudmetrics', $this->get_label()));
             }
             $count++;
-            $this->mintimestamp = $time;
+            $mintimestamp = $time;
         }
         $rs->close();
-
-    }
-
-    /**
-     * Stores what data has been sent to collector.
-     *
-     */
-    public function set_data_sent_config() {
-        // Store what data has been sent min, max timestamp range and interval.
-        $currentconfig = [$this->mintimestamp, $this->maxtimestamp, $this->interval];
-        $rangeretrieved = $this->get_range_retrieved();
-        $this->sameconfig = ($rangeretrieved === $currentconfig);
-        if (!$this->sameconfig && isset($this->mintimestamp) && isset($this->maxtimestamp) && isset($this->interval)) {
-            $this->set_range_retrieved($currentconfig);
-        }
     }
 }

--- a/classes/metric/test_metric.php
+++ b/classes/metric/test_metric.php
@@ -37,10 +37,6 @@ class test_metric extends base {
     public $variance = 10;
     /** @var int The frequency of the metric's sampling. */
     public $frequency = manager::FREQ_MIN;
-    /** @var bool Is the metric switched on. */
-    public $enabled = false;
-    /** @var bool Is the metric ready. */
-    public $isready = true;
 
     /**
      * The metric's name.
@@ -115,30 +111,21 @@ class test_metric extends base {
     }
 
     /**
-     * Is the metric switched on?
+     * Metric's ability to be backfilled.
      *
      * @return bool
      */
-    public function is_enabled(): bool {
-        return $this->enabled;
+    public function is_backfillable(): bool {
+        return true;
     }
 
     /**
-     * Sets the enabled status.
-     *
-     * @param bool $enabled
-     */
-    public function set_enabled(bool $enabled) {
-        $this->enabled = $enabled;
-    }
-
-    /**
-     * Is the metric ready?
+     * Metric's ability to be backfilled automatically.
      *
      * @return bool
      */
-    public function is_ready(): bool {
-        return $this->isready;
+    public function is_autobackfill() {
+        return true;
     }
 
     /**
@@ -152,5 +139,15 @@ class test_metric extends base {
         $item = new metric_item($this->get_name(), $finishtime, $this->value, $this);
         $this->value += rand(-$this->variance, $this->variance);
         return $item;
+    }
+
+    public function generate_metric_items(int $backwardperiod, int $finishtime = null): \Iterator {
+        $finishtime = $finishtime ?? time();
+        $start = time() - $backwardperiod;
+        $items = [];
+        for ($time = $start; $time <= $finishtime; $time = lib::get_next_time($time, $this->get_frequency())) {
+            $items[] = $this->generate_metric_item(lib::get_previous_time($time, $this->get_frequency()), $time);
+        }
+        return new \ArrayIterator($items);
     }
 }

--- a/classes/metric/yearly_active_users_metric.php
+++ b/classes/metric/yearly_active_users_metric.php
@@ -28,20 +28,6 @@ use tool_cloudmetrics\lib;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class yearly_active_users_metric extends builtin_user_base {
-
-
-    /** @var int The interval config for which data is displayed in seconds (eg: 5 minutes = 300). */
-    public $interval;
-
-    /** @var int The minimal timestamp representing earliest date retrieved in DB. */
-    public $mintimestamp;
-
-    /** @var int The maximal timestamp representing latest date retrieved in DB. */
-    public $maxtimestamp;
-
-    /** @var bool True if config used is same as one requested. */
-    public $sameconfig;
-
     /**
      * The metric's name.
      *
@@ -159,9 +145,6 @@ class yearly_active_users_metric extends builtin_user_base {
             return new \EmptyIterator();
         }
 
-        $this->maxtimestamp = $finishtime;
-        $this->interval = $frequency;
-
         $sql = "SELECT COUNT(DISTINCT userid)
                   FROM {logstore_standard_log}
                  WHERE timecreated >= :from
@@ -179,7 +162,6 @@ class yearly_active_users_metric extends builtin_user_base {
                 $sql,
                 ['from' => $lastyear, 'to' => $time]
             );
-            $this->mintimestamp = $time;
             yield new metric_item($this->get_name(), $time, $activeusers, $this);
             $time -= $interval;
             $count++;
@@ -190,20 +172,6 @@ class yearly_active_users_metric extends builtin_user_base {
                     get_string('backfillgenerating', 'tool_cloudmetrics', $this->get_label())
                 );
             }
-        }
-    }
-
-    /**
-     * Stores what data has been sent to collector.
-     *
-     */
-    public function set_data_sent_config(): void {
-        // Store what data has been sent min, max timestamp range and interval.
-        $currentconfig = [$this->mintimestamp, $this->maxtimestamp, $this->interval];
-        $rangeretrieved = $this->get_range_retrieved();
-        $this->sameconfig = ($rangeretrieved === $currentconfig);
-        if (!$this->sameconfig && isset($this->mintimestamp) && isset($this->maxtimestamp) && isset($this->interval)) {
-            $this->set_range_retrieved($currentconfig);
         }
     }
 }

--- a/classes/task/autobackfill_metrics_task.php
+++ b/classes/task/autobackfill_metrics_task.php
@@ -17,6 +17,7 @@
 namespace tool_cloudmetrics\task;
 
 use tool_cloudmetrics\metric;
+use tool_cloudmetrics\collector\manager;
 use tool_cloudmetrics\plugininfo\cltr;
 
 /**
@@ -28,9 +29,11 @@ use tool_cloudmetrics\plugininfo\cltr;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class autobackfill_metrics_task extends \core\task\adhoc_task {
-
     /** @var array Enabled plugins */
     private array $plugins;
+
+    /** @var \tool_cloudmetrics\collector\base|null */
+    private ?\tool_cloudmetrics\collector\base $collector  = null;
 
     /**
      * Get task name
@@ -50,11 +53,19 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
             mtrace('No metrics to send at the moment');
             return;
         }
-        foreach ($this->plugins as $plugin) {
-            $collector = $plugin->get_collector();
-            if ($collector->supports_backfillable_metrics()) {
-                $collector->record_saved_metrics($metricclass, $metricitems);
-                mtrace(sprintf("Recorded %s '%s' metrics to %s", count($metricitems), $metricclass->get_name(), $plugin->name));
+        if (!empty($this->collector)) {
+            $this->collector->record_metrics($metricitems);
+            mtrace(sprintf("Recorded %s '%s' metrics", count($metricitems), $metricclass->get_name()));
+        } else {
+            foreach ($this->plugins as $plugin) {
+                $collector = $plugin->get_collector();
+                if ($collector->supports_backfillable_metrics()) {
+                    $collector->record_metrics($metricitems);
+                    if ($collector->is_readable()) {
+                        $collector->set_last_backfilled_frequency($metricclass->get_name(), $metricclass->get_frequency());
+                    }
+                    mtrace(sprintf("Recorded %s '%s' metrics to %s", count($metricitems), $metricclass->get_name(), $plugin->name));
+                }
             }
         }
     }
@@ -70,6 +81,28 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
         }
 
         $customdata = $this->get_custom_data();
+        $collector = null;
+        if (isset($customdata->collector)) {
+            $collector = manager::get_collector($customdata->collector);
+            if (!$collector->supports_backfillable_metrics()) {
+                mtrace('No backfillable collectors to send metrics to!');
+                return;
+            }
+            $this->collector = $collector;
+        } else {
+            $proceedwithbackfill = false;
+            foreach ($this->plugins as $plugin) {
+                $collector = $plugin->get_collector();
+                if ($collector->supports_backfillable_metrics()) {
+                    $proceedwithbackfill = true;
+                }
+            }
+            if (!$proceedwithbackfill) {
+                mtrace('No backfillable collectors to send metrics to!');
+                return;
+            }
+        }
+
         $nowts = time();
         $collectingperiod = $customdata->period ?? YEARSECS;
         $autobackfill = !isset($customdata->metric);
@@ -106,10 +139,13 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
             $finishtime = $nowts;
 
             // Check if data has already been backfilled.
-            [$backfillmin, $backfillmax, $backfillinterval] = $metrictype->get_range_retrieved();
-            if ($backfillinterval === $metrictype->get_frequency() && $backfillmin > 0) {
-                // If a backfill range exists for this frequency, we only need to backfill older data.
-                $finishtime = $backfillmin;
+            if ($collector && $collector->is_readable()) {
+                $range = $collector->get_metric_range($metrictype->get_name());
+                if (!is_null($range)) {
+                    // We only need to backfill further back than this time.
+                    // We subtract 1 because we don't want to include it.
+                    $finishtime = $range['mintime'] - 1;
+                }
             }
 
             if ($finishtime < $starttime) {
@@ -145,9 +181,9 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
                 $count = count($metrics);
             }
 
-            mtrace(sprintf('Generated %s %s metrics', $count,  $metrictype->get_name()));
+            mtrace(sprintf('Generated %s %s metrics', $count, $metrictype->get_name()));
             $total += $count;
         }
-        mtrace('Backfilled totally '.$total.' metrics');
+        mtrace('Backfilled totally ' . $total . ' metrics');
     }
 }

--- a/collector/cloudwatch/classes/collector.php
+++ b/collector/cloudwatch/classes/collector.php
@@ -75,10 +75,10 @@ class collector extends base {
      * Record an array of metric data
      *
      * @param array $items
-     * @param \progress_bar|null $progress
+     * @param ?\progress_bar|null $progress
      * @return mixed
      */
-    public function record_metrics(array $items, \progress_bar $progress = null) {
+    public function record_metrics(array $items, ?\progress_bar $progress = null) {
         $metricdata = [];
         foreach ($items as $item) {
             $metricdata[] = $this->make_metric_data_entry($item);

--- a/collector/database/backfill.php
+++ b/collector/database/backfill.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__.'/../../../../../config.php');
+require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 
 use tool_cloudmetrics\metric\manager;
@@ -69,23 +69,33 @@ $periods = [
     YEARSECS * 2  => get_string('two_year', 'tool_cloudmetrics'),
 ];
 
-// Gets already saved data range and interval.
-[$mintmptmp, $maxtmpstmp, $freqretrieved] = $metrics[$metricname]->get_range_retrieved();
-if ($mintmptmp != -1) {
-    $backfilledfrom = userdate($mintmptmp, get_string('strftimedatetime', 'cltr_database'), $CFG->timezone);
-    $backfilledto = userdate($maxtmpstmp, get_string('strftimedatetime', 'cltr_database'), $CFG->timezone);
-    $backfilledinterval = (int)$freqretrieved;
-    if ($backfilledinterval !== $metrics[$metricname]->get_frequency()) {
-        $isdifferentfreq = true;
-        $context['cautiondata'] = get_string('different_freq', 'tool_cloudmetrics',
-            ['backfilledfrom' => $backfilledfrom, 'backfilledto' => $backfilledto]);;
+if ($collector->is_readable()) {
+    // Get some information about existing data.
+    $range = $collector->get_metric_range($metricname);
+    $freqretrieved = $collector->get_last_backfilled_frequency($metricname);
+    if (!empty($range)) {
+        ['mintime' => $mintmptmp, 'maxtime' => $maxtmpstmp] = $range;
+        $backfilledfrom = userdate($mintmptmp, get_string('strftimedatetime', 'cltr_database'), $CFG->timezone);
+        $backfilledto = userdate($maxtmpstmp, get_string('strftimedatetime', 'cltr_database'), $CFG->timezone);
+        $backfilledinterval = (int)$freqretrieved;
+        if ($backfilledinterval !== $metrics[$metricname]->get_frequency()) {
+            $isdifferentfreq = true;
+            $context['cautiondata'] = get_string(
+                'different_freq',
+                'tool_cloudmetrics',
+                ['backfilledfrom' => $backfilledfrom, 'backfilledto' => $backfilledto]
+            );
+        } else {
+            $isdifferentfreq = false;
+        }
+        $context['dataindb'] = get_string(
+            'data_in_db',
+            'tool_cloudmetrics',
+            ['dbstart' => $backfilledfrom, 'dbend' => $backfilledto]
+        );
     } else {
-        $isdifferentfreq = false;
+        $emptydb = get_string('data_empty', 'tool_cloudmetrics');
     }
-    $context['dataindb'] = get_string('data_in_db', 'tool_cloudmetrics',
-            ['dbstart' => $backfilledfrom, 'dbend' => $backfilledto]);
-} else {
-    $emptydb = get_string('data_empty', 'tool_cloudmetrics');
 }
 // Gets available data to backfill.
 $daterange = $metrics[$metricname]->get_range_log_available();
@@ -94,8 +104,11 @@ $enddate = userdate($daterange->max, get_string('strftimedatetime', 'cltr_databa
 $mform = new metric_backfill_form(null, [$daterange, $periods, $metricname]);
 $context['form'] = $mform->render();
 
-$context['dataperiod'] = get_string('data_period', 'tool_cloudmetrics',
-            ['startdate' => $startdate ?? 0, 'enddate' => $enddate ?? 0]);
+$context['dataperiod'] = get_string(
+    'data_period',
+    'tool_cloudmetrics',
+    ['startdate' => $startdate ?? 0, 'enddate' => $enddate ?? 0]
+);
 $context['emptydb'] = $emptydb ?? false;
 $context['linktochart'] = $tochart;
 $context['metriclabel'] = $metrics[$metricname]->get_label();

--- a/collector/database/classes/collector.php
+++ b/collector/database/classes/collector.php
@@ -86,7 +86,7 @@ class collector extends base {
         if ($since) {
             $starting = " AND time > " . (time() - $since);
         }
-        list ($clause, $params) = $DB->get_in_or_equal($metricnames);
+        [$clause, $params] = $DB->get_in_or_equal($metricnames);
         $sql = "SELECT id, name, date, time, value
                   FROM {cltr_database_metrics}
                  WHERE name $clause
@@ -129,7 +129,7 @@ class collector extends base {
         } else {
             $incrementstart = "FLOOR(time/$aggregate) * $aggregate AS increment_start";
         }
-        list ($clause, $params) = $DB->get_in_or_equal($metricnames);
+        [$clause, $params] = $DB->get_in_or_equal($metricnames);
         if (count($metricnames) == 1) {
             $sql = "SELECT AVG(" . $DB->sql_cast_char2int('value', true) . ") AS \"$metricnames[0]\",
                 MIN(" . $DB->sql_cast_char2int('value', true) . ") AS min,
@@ -157,21 +157,19 @@ class collector extends base {
     }
 
     /**
-     * Records retrieved data in collector.
+     * Records a number of metrics.
      *
-     * @param \tool_cloudmetrics\metric\base $metricclass Class representing metric.
-     * @param array $metricitems Array of metric items.
+     * @param array $metrics
      * @param \progress_bar|null $progress
+     * @return mixed
      */
-    public function record_saved_metrics(\tool_cloudmetrics\metric\base $metricclass, array $metricitems = [], \progress_bar $progress = null) {
+    public function record_metrics(array $metrics, ?\progress_bar $progress = null) {
         global $DB;
-        $transaction = $DB->start_delegated_transaction();
-        if (count($metricitems) != 0 && !$metricclass->sameconfig) {
-            $this->record_metrics($metricitems, $progress);
+        if (count($metrics) != 0) {
+            $transaction = $DB->start_delegated_transaction();
+            parent::record_metrics($metrics, $progress);
+            $transaction->allow_commit();
         }
-        $transaction->allow_commit();
-        // Sets what data has been sent to collector.
-        $metricclass->set_data_sent_config();
     }
 
     /**
@@ -204,5 +202,55 @@ class collector extends base {
      */
     public function is_auto_backfill(): bool {
         return lib::get_metric_auto_backfill();
+    }
+
+    /**
+     * Can we retrieve saved metrics from this collector?
+     *
+     * @return bool
+     */
+    public function is_readable(): bool {
+        return true;
+    }
+
+    /**
+     * Gets the range of the currently stored metric data.
+     *
+     * @param string $metricname
+     * @return ?array An array of start and end, or null if no data is found.
+     * @throws \dml_exception
+     */
+    public function get_metric_range(string $metricname): ?array {
+        global $DB;
+        $sql = "SELECT MIN(time) AS mintime, MAX(time) AS maxtime FROM {cltr_database_metrics} WHERE name = :metricname";
+        $params = ['metricname' => $metricname];
+        $record = $DB->get_record_sql($sql, $params);
+        // Only need to test one, because they are either both null or both not null.
+        if ($record->mintime === null) {
+            return null;
+        }
+        return (array) $record;
+    }
+
+    /**
+     * Gets the last backfilled frequency set via set_last_backfilled_frequency.
+     * Note: This value does not necessarily reflect the actual frequency of the stored data.
+     *
+     * @param string $metricname
+     * @return int|false
+     */
+    public function get_last_backfilled_frequency(string $metricname) {
+        return get_config('cltr_database', $metricname . '_lastfreq');
+    }
+
+    /**
+     * Sets the last backfilled frequency.
+     * Note: This value does not necessarily reflect the actual frequency of the stored data.
+     *
+     * @param string $metricname
+     * @param int $frequency
+     */
+    public function set_last_backfilled_frequency(string $metricname, int $frequency): void {
+        set_config($metricname . '_lastfreq', $frequency, 'cltr_database');
     }
 }

--- a/collector/database/classes/lib.php
+++ b/collector/database/classes/lib.php
@@ -32,7 +32,7 @@ class lib {
     const TABLE = 'cltr_database_metrics';
 
     /**
-     * Returns if a collector supports is auto backfilling.
+     * Returns if auto backfilling is enabled.
      *
      * @return bool
      * @throws \dml_exception
@@ -52,7 +52,7 @@ class lib {
     }
 
     /**
-     * Returns the midnight time of whatever date string is porvided.
+     * Returns the midnight time of whatever date string is provided.
      *
      * In PHP, when processing a date string, the 'midnight' clause is processed before any =/- relative amounts.
      * So the string '+5hour midnight' is the same as 'midnight +5hours'.
@@ -78,7 +78,7 @@ class lib {
     }
 
     /**
-     * Returns a calculated default chart period based on the sample interval of $metricname.
+     * Returns a calculated default chart period based on the sample interval of $metric.
      *
      * @param metric\base $metric
      * @return int

--- a/collector/database/tests/cltr_database_test.php
+++ b/collector/database/tests/cltr_database_test.php
@@ -23,6 +23,7 @@ require_once(__DIR__ . "/../../../tests/metric_testcase.php"); // This is needed
 use tool_cloudmetrics\metric\manager;
 use tool_cloudmetrics\metric\online_users_metric;
 use tool_cloudmetrics\metric\active_users_metric;
+use tool_cloudmetrics\collector\manager as collectormanager;
 
 /**
  * Unit test for database collector
@@ -31,9 +32,9 @@ use tool_cloudmetrics\metric\active_users_metric;
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \cltr_database\collector
  */
-class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
-
+final class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     /** @var int Hours in a day*/
     const DAYHOURS = 24;
 
@@ -48,6 +49,18 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     }
 
     /**
+     * Test the basic properties of a database collector.
+     */
+    public function test_basic_properties(): void {
+        $collector = collectormanager::get_collector('database');
+        $this->assertEquals('cltr_database\\collector', $collector::class);
+
+        $this->assertTrue($collector->is_readable());
+        $this->assertTrue($collector->supports_backfillable_metrics());
+        $this->assertTrue($collector->is_auto_backfill());
+    }
+
+    /**
      * Test get_midnight_of.
      *
      * @dataProvider midnight_provider
@@ -55,7 +68,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      * @param string $datestr
      * @param string  $expected   The expected result of the transformation
      */
-    public function test_midnight(string $datestr, string $expected) {
+    public function test_midnight(string $datestr, string $expected): void {
         $tz = \core_date::get_server_timezone_object();
         $time = lib::get_midnight_of($datestr, $tz);
         $expecteddate = new \DateTimeImmutable($expected, $tz);
@@ -69,7 +82,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return \string[][]
      */
-    public function midnight_provider(): array {
+    public static function midnight_provider(): array {
         return [
             ['today -5 hours', 'yesterday'],
             ['today +20 hours', 'today'],
@@ -91,7 +104,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      * @param string $datestr
      * @param string $expected
      */
-    public function test_midnight_timestamp(string $datestr, string $expected) {
+    public function test_midnight_timestamp(string $datestr, string $expected): void {
         $tz = \core_date::get_server_timezone_object();
         $ti = new \DateTimeImmutable($datestr, $tz);
         $ts = $ti->getTimestamp();
@@ -105,7 +118,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @covers \cltr_database\collector
      */
-    public function test_collector() {
+    public function test_collector(): void {
         global $DB;
 
         $stub = $this->get_metric_stub([1, 2, 3]);
@@ -155,64 +168,29 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
     }
 
     /**
-     * Test backfillable metric, here the 'active' metric.
+     * Test get_metric_range()
      *
-     * @covers \cltr_database\collector::record_saved_metrics
+     * @return void
+     * @throws \dml_exception
      */
-    public function test_backfillable_metric() {
-        global $DB;
-
-        $onlinemetric = new online_users_metric();
-        $activemetric = new active_users_metric();
+    public function test_get_metric_range(): void {
+        $stub = $this->get_metric_stub([1, 2, 3]);
         $collector = new collector();
 
-        $onlinebackfill = $onlinemetric->is_backfillable();
-        $activemetricbackfill = $activemetric->is_backfillable();
+        // Test nothing in database.
+        $range = $collector->get_metric_range('mock');
+        $this->assertNull($range);
 
-        $rec = $DB->get_records(lib::TABLE);
-        $this->assertEquals(0, count($rec));
-        $this->assertTrue($onlinebackfill);
-        $this->assertFalse($activemetricbackfill);
+        for ($time = 100; $time <= 200; $time += 10) {
+            $collector->record_metric($stub->generate_metric_item(0, $time));
+        }
 
-        // We did not fill logstore_standard_log db yet.
-        $collector->record_saved_metrics($onlinemetric, []);
-        $rec = $DB->get_records(lib::TABLE);
-        $this->assertEquals(0, count($rec));
-        $dataobjects = [];
-        $res = (1590580800 - 1590465600) / 100;
-        for ($i = 1590465600; $i < 1590580800; $i += $res) {
-            $dataobjects[] = [
-                'eventname' => '\core\event\user_created',
-                'component' => 'core',
-                'action' => 'loggedin',
-                'target' => 'user',
-                'crud' => 'r',
-                'edulevel' => 0,
-                'contextid' => 1,
-                'contextlevel' => 10,
-                'contextinstanceid' => 0,
-                'userid' => $i,
-                'anonymous' => 0,
-                'timecreated' => $i,
-            ];
-        }
-        set_config('enabled_stores', 'logstore_standard', 'tool_log');
-        $plugins = get_config('tool_log', 'enabled_stores');
-        $this->assertEquals('logstore_standard', $plugins);
-        $DB->insert_records('logstore_standard_log', $dataobjects);
-        $rec = $DB->get_records('logstore_standard_log');
-        $this->assertEquals(100, count($rec));
-        $metrics = iterator_to_array($onlinemetric->generate_metric_items(1590465600, 1590580800));
-        $collector->record_saved_metrics($onlinemetric, $metrics);
-        $rec = $DB->get_records(lib::TABLE);
-        $count = 0;
-        foreach ($rec as $r) {
-            $remainder = $r->time % 300;
-            $this->assertEquals($onlinemetric->get_name(), $r->name);
-            $this->assertEquals($remainder, 0);
-            $count++;
-        }
-        $this->assertEquals(381, $count);
+        // Test range values.
+        $range = $collector->get_metric_range('mock');
+        $this->assertTrue(isset($range['mintime']));
+        $this->assertTrue(isset($range['maxtime']));
+        $this->assertEquals(100, $range['mintime']);
+        $this->assertEquals(200, $range['maxtime']);
     }
 
     /**
@@ -227,7 +205,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      * @param int $numexpected
      * @throws \dml_exception
      */
-    public function test_expiry(int $daysago, int $houradjustment, int $expiry, int $numrecords, int $numexpected) {
+    public function test_expiry(int $daysago, int $houradjustment, int $expiry, int $numrecords, int $numexpected): void {
         global $DB;
 
         $tz = \core_date::get_server_timezone_object();
@@ -275,7 +253,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return array
      */
-    public function expiry_provider(): array {
+    public static function expiry_provider(): array {
         return [
             [20, 10, 10 * DAYSECS, 20, 10],
             [20, -2, 10 * DAYSECS, 20, 9],
@@ -291,7 +269,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      * @param int $freq
      * @param int $expected
      */
-    public function test_period_from_interval(int $freq, int $expected) {
+    public function test_period_from_interval(int $freq, int $expected): void {
         $metric = new \tool_cloudmetrics\metric\online_users_metric();
         $metric->set_frequency($freq);
         $this->assertEquals($expected, lib::period_from_interval($metric));
@@ -302,7 +280,7 @@ class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
      *
      * @return array[]
      */
-    public function period_from_interval_provider(): array {
+    public static function period_from_interval_provider(): array {
         return [
             [ manager::FREQ_MIN, DAYSECS * 7],
             [ manager::FREQ_5MIN, DAYSECS * 7],

--- a/lang/en/tool_cloudmetrics.php
+++ b/lang/en/tool_cloudmetrics.php
@@ -82,7 +82,7 @@ $string['yearlyactiveusers_desc'] = 'Users that have been active within the past
 $string['data_empty'] = 'Your database for this metric is empty.';
 $string['data_in_db'] = 'Your database contains data from {$a->dbstart} to {$a->dbend}.';
 $string['data_period'] = 'Current information shows data can be retrieved from {$a->startdate} to {$a->enddate}.';
-$string['different_freq'] = 'Caution - frequency has been changed, new data will complete currently present but no data will be added between
+$string['different_freq'] = 'Caution - Current frequency is different from the last backfill, new data will complete currently present but no data will be added between
 {$a->backfilledfrom} and {$a->backfilledto}.';
 $string['period_select'] = 'Select period to retrieve data from: ';
 $string['return_to_backfill'] = 'Backfill {$a} period';

--- a/lib.php
+++ b/lib.php
@@ -26,6 +26,7 @@
 use tool_cloudmetrics\metric\active_users_metric;
 use tool_cloudmetrics\metric\manager;
 use core\output\inplace_editable;
+use core_external\external_api;
 
 /**
  * Update the frequency config for metrics.
@@ -43,7 +44,7 @@ use core\output\inplace_editable;
  */
 function tool_cloudmetrics_inplace_editable(string $itemtype, int $itemid, string $newvalue) {
     if ($itemtype == 'metrics_freq') {
-        \external_api::validate_context(\context_system::instance());
+        external_api::validate_context(\context_system::instance());
         require_capability('moodle/site:config', \context_system::instance());
         $metrics = manager::get_metrics(false);
         $metric = null;

--- a/tests/metric_testcase.php
+++ b/tests/metric_testcase.php
@@ -16,6 +16,7 @@
 
 namespace tool_cloudmetrics;
 
+use tool_cloudmetrics\lib;
 use tool_cloudmetrics\metric\base;
 use tool_cloudmetrics\metric\metric_item;
 
@@ -28,7 +29,6 @@ use tool_cloudmetrics\metric\metric_item;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class metric_testcase extends \advanced_testcase {
-
     /**
      * Returns a test stub for a metric that gives items, cycling through
      * the array of values, repeating when it gets to the end.
@@ -55,11 +55,41 @@ class metric_testcase extends \advanced_testcase {
             ->willReturn($isready);
 
         $stub->method('generate_metric_item')
-            ->willReturnCallback(function($start, $finish) use ($stub, $infinate) {
+            ->willReturnCallback(function ($start, $finish) use ($stub, $infinate) {
                 $value = $infinate->current();
                 $infinate->next();
                 $item = new metric_item('mock', $finish, $value, $stub);
                 return $item;
+            });
+
+        return $stub;
+    }
+
+    /**
+     * Returns a test stub that does all of the above plus is able to give items from the past.
+     *
+     * @param array $cycle A cycle of values to be repeated infinitely.
+     * @param int $frequency A frequency value as defined in manager class.
+     * @param bool $isready Whether the mock object is available for use.
+     */
+    protected function get_backfillable_metric_stub(array $cycle, int $frequency, bool $isready = true) {
+        $stub = $this->get_metric_stub($cycle, $isready);
+
+        $stub->method('get_frequency')
+            ->willReturn($frequency);
+        $stub->method('is_backfillable')
+            ->willReturn(true);
+        $stub->method('is_autobackfill')
+            ->willReturn(true);
+
+        $stub->method('generate_metric_items')
+            ->willReturnCallback(function ($backtime, $finish) use ($stub, $frequency) {
+                $start = $finish - $backtime;
+                $items = [];
+                for ($time = $start; $time <= $finish; $time = lib::get_next_time($time, $frequency)) {
+                    $items[] = $stub->generate_metric_item(0, $time);
+                }
+                return new \ArrayIterator($items);
             });
 
         return $stub;

--- a/tests/tool_cloudmetrics_autobackfill_metrics_task_test.php
+++ b/tests/tool_cloudmetrics_autobackfill_metrics_task_test.php
@@ -1,0 +1,82 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_cloudmetrics;
+
+use cltr_database\lib;
+use tool_cloudmetrics\metric\test_metric;
+use tool_cloudmetrics\task\autobackfill_metrics_task;
+
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/metric_testcase.php"); // This is needed. File will not be automatically included.
+
+/**
+ * Tests the autobackfill metrics task.
+ *
+ * @package tool_cloudmetrics
+ * @author Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2026 Catalyst IT
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \tool_cloudmetrics\task\autobackfill_metrics_task
+ */
+final class tool_cloudmetrics_autobackfill_metrics_task_test extends metric_testcase {
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Tests the task execution.
+     */
+    public function test_execute(): void {
+        global $DB;
+
+        ob_start();
+        $metricname = 'foobar';
+        $metric = new test_metric();
+        $metric->set_enabled(true);
+        $collectorname = 'database';
+        $task = new autobackfill_metrics_task();
+
+        $task->set_custom_data([
+            'metric' => $metricname,
+            'period' => MINSECS * 10,
+            'collector' => $collectorname,
+        ]);
+
+        $task->execute();
+        $c1 = $DB->count_records(lib::TABLE);
+        // There should be 11 entries because the range is inclusive.
+        $this->assertEquals(11, $c1);
+
+        $task->set_custom_data([
+            'metric' => $metricname,
+            'period' => MINSECS * 20,
+            'collector' => $collectorname,
+        ]);
+
+        $task->execute();
+        $c2 = $DB->count_records(lib::TABLE);
+        // Only 10 extra entries should be added.
+        $this->assertEquals(21, $c2);
+        ob_end_clean();
+    }
+}

--- a/tests/tool_cloudmetrics_metric_stub_test.php
+++ b/tests/tool_cloudmetrics_metric_stub_test.php
@@ -16,6 +16,8 @@
 
 namespace tool_cloudmetrics;
 
+use tool_cloudmetrics\metric\manager;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . "/metric_testcase.php"); // This is needed. File will not be automatically included.
@@ -27,10 +29,13 @@ require_once(__DIR__ . "/metric_testcase.php"); // This is needed. File will not
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_cloudmetrics\metric_testcase
  */
-class tool_cloudmetrics_metric_stub_test extends metric_testcase {
-
-    public function test_get_stub() {
+final class tool_cloudmetrics_metric_stub_test extends metric_testcase {
+    /**
+     * Tests that the test metric stub works.
+     */
+    public function test_get_stub(): void {
         $stub = $this->get_metric_stub([1, 2, 3]);
 
         $time = 100;
@@ -52,5 +57,32 @@ class tool_cloudmetrics_metric_stub_test extends metric_testcase {
         $i = $stub->generate_metric_item(0, $time);
         $this->assertEquals(1, $i->value);
         $this->assertEquals($time, $i->time);
+    }
+
+    /**
+     * Tests that the backfillable test stub works.
+     */
+    public function test_get_backfillable_metric_stub(): void {
+        $cycle = [1, 2, 3];
+        $infinate = new \InfiniteIterator(new \ArrayIterator($cycle));
+        $infinate->rewind();
+
+        $frequency = manager::FREQ_MIN;
+        $stub = $this->get_backfillable_metric_stub($cycle, $frequency);
+        $start = 100;
+        $finish = 340;
+
+        $items = $stub->generate_metric_items($finish - $start, $finish, $frequency);
+
+        $time = $start;
+        foreach ($items as $item) {
+            $value = $infinate->current();
+            $infinate->next();
+
+            $this->assertEquals($value, $item->value);
+            $this->assertEquals($time, $item->time);
+            $time = lib::get_next_time($time, $frequency);
+        }
+        $this->assertGreaterThan($finish, $time);
     }
 }

--- a/tests/tool_cloudmetrics_online_users_metric_test.php
+++ b/tests/tool_cloudmetrics_online_users_metric_test.php
@@ -17,6 +17,7 @@
 namespace tool_cloudmetrics;
 
 use tool_cloudmetrics\metric\online_users_metric;
+use tool_cloudmetrics\metric\manager;
 
 /**
  * Unit test for online users metric.
@@ -24,9 +25,9 @@ use tool_cloudmetrics\metric\online_users_metric;
  * @package   tool_cloudmetrics
  * @copyright 2025, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_cloudmetrics\metric\online_users_metric
  */
 final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcase {
-
     /**
      * Set up before each test
      */
@@ -37,8 +38,6 @@ final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcas
 
     /**
      * Tests generate metric items
-     *
-     * @covers \tool_cloudmetrics\metric\generate_metric_items
      */
     public function test_generate_metric_items(): void {
         global $DB;
@@ -85,17 +84,17 @@ final class tool_cloudmetrics_online_users_metric_test extends \advanced_testcas
         $this->assertEmpty($metrics);
 
         // Frequency periods.
-        $freq1 = 60;
-        $freq2 = 300;
+        $freq1 = \tool_cloudmetrics\lib::FREQ_TIMES[manager::FREQ_MIN];
+        $freq2 = \tool_cloudmetrics\lib::FREQ_TIMES[manager::FREQ_5MIN];
 
         // Get metrics for previous year with frequency 60 seconds.
-        $onlinemetric->set_frequency(1);
+        $onlinemetric->set_frequency(manager::FREQ_MIN);
         $metrics = iterator_to_array($onlinemetric->generate_metric_items(31556926));
         $count = ($metrics[0]->time - end($metrics)->time) / $freq1 + 1;
         $this->assertCount($count, $metrics);
 
         // Get metrics for previous year with frequency 300 seconds.
-        $onlinemetric->set_frequency(2);
+        $onlinemetric->set_frequency(manager::FREQ_5MIN);
         $metrics = iterator_to_array($onlinemetric->generate_metric_items(31556926));
         $count = ($metrics[0]->time - end($metrics)->time) / $freq2 + 1;
         $this->assertCount($count, $metrics);

--- a/tests/tool_cloudmetrics_users_test.php
+++ b/tests/tool_cloudmetrics_users_test.php
@@ -29,9 +29,11 @@ use tool_cloudmetrics\metric\yearly_active_users_metric;
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_cloudmetrics\metric\active_users_metric
+ * @covers    \tool_cloudmetrics\metric\online_users_metric
+ * @covers    \tool_cloudmetrics\metric\new_users_metric
  */
 final class tool_cloudmetrics_users_test extends \advanced_testcase {
-
     /**
      * Set up before each test
      */
@@ -39,8 +41,6 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
         parent::setUp();
         $this->resetAfterTest();
     }
-    /** @var integer Seconds in a day. */
-    public const SECOND_IN_DAY = 86400;
 
     /** @var array[] Sample user DB data to be used in tests. */
     public const USER_DATA = [
@@ -54,20 +54,6 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
         ['username' => 'h', 'firstaccess' => 12600, 'lastaccess' => 11000, 'lastlogin' => 12777],
         ['username' => 'i', 'firstaccess' => 12800, 'lastaccess' => 100, 'lastlogin' => 12882],
         ['username' => 'j', 'firstaccess' => 13000, 'lastaccess' => 12950, 'lastlogin' => 12500],
-    ];
-
-    /** @var array[] Sample active user DB data to be used in tests. */
-    public const ACTIVE_USER_DATA = [
-        ['username' => 'a', 'confirmed' => 1 , 'lastlogin' => self::SECOND_IN_DAY + 1000],
-        ['username' => 'b', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 2) + 1000],
-        ['username' => 'c', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 2) + 2000],
-        ['username' => 'd', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 2) + 3000],
-        ['username' => 'e', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 3) + 1000],
-        ['username' => 'f', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 3) + 2000],
-        ['username' => 'g', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 4) + 1000],
-        ['username' => 'h', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 4) + 2000],
-        ['username' => 'i', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 5) + 1000],
-        ['username' => 'j', 'confirmed' => 1 , 'lastlogin' => (self::SECOND_IN_DAY * 5) + 2000],
     ];
 
     /**
@@ -102,39 +88,12 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
         $this->assertEquals($expected, $items);
     }
 
-
-    /**
-     * Tests test_generate_yearly_active_users_metric() for the builtin user metrics.
-     *
-     * @dataProvider data_for_test_generate_yearly_active_users_metric
-     * @param string $metricname The name of the metric to be tested.
-     * @param array $expected List of metric items that expect to be generated.
-     * @throws \dml_exception
-     */
-    public function test_generate_yearly_active_users_metric(string $metricname, array $expected): void {
-        global $DB;
-
-        foreach (self::ACTIVE_USER_DATA as $row) {
-            $DB->insert_record('user', (object) $row);
-        }
-        $time = self::SECOND_IN_DAY * 366;
-        $endtime = $time + (4 * lib::FREQ_TIMES[metric\manager::FREQ_DAY]);
-        $metrictypes = metric\manager::get_metrics(false);
-        $metric = $metrictypes[$metricname];
-        $this->assertEquals($metricname, $metric->get_name());
-        while ($time <= $endtime) {
-            $items[] = $metric->generate_metric_item(0, $time);
-            $time = lib::get_next_time($time, metric\manager::FREQ_DAY);
-        }
-        $this->assertEquals($expected, $items);
-
-    }
     /**
      * Data provider for test_generate_metrics.
      *
      * @return array[]
      */
-    public function data_for_test_generate_metrics(): array {
+    public static function data_for_test_generate_metrics(): array {
         $newusersmetric = new new_users_metric();
         $activeusersmetric = new active_users_metric();
         $onlineusersmetric = new online_users_metric();
@@ -163,25 +122,6 @@ final class tool_cloudmetrics_users_test extends \advanced_testcase {
                     new metric_item('onlineusers', 13000, 2, $onlineusersmetric),
                 ],
             ],
-        ];
-    }
-
-    /**
-     * Data provider for test_generate_yearly_active_users_metric.
-     *
-     * @return array[]
-     */
-    public function data_for_test_generate_yearly_active_users_metric(): array {
-        $yearlyactiveusers = new yearly_active_users_metric();
-
-        return [
-             ['yearlyactiveusers', [
-                new metric_item('yearlyactiveusers', self::SECOND_IN_DAY * 366 , 10, $yearlyactiveusers),
-                new metric_item('yearlyactiveusers', self::SECOND_IN_DAY * 367, 9, $yearlyactiveusers),
-                new metric_item('yearlyactiveusers', self::SECOND_IN_DAY * 368, 6, $yearlyactiveusers),
-                new metric_item('yearlyactiveusers', self::SECOND_IN_DAY * 369, 4, $yearlyactiveusers),
-                new metric_item('yearlyactiveusers', self::SECOND_IN_DAY * 370, 2, $yearlyactiveusers)],
-             ],
         ];
     }
 }

--- a/tests/tool_cloudmetrics_yearly_active_users_test.php
+++ b/tests/tool_cloudmetrics_yearly_active_users_test.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_cloudmetrics;
+
+use tool_cloudmetrics\metric\metric_item;
+use tool_cloudmetrics\metric\yearly_active_users_metric;
+
+/**
+ * Tests for the yearly_active_users metric.
+ *
+ * @package tool_cloudmetrics
+ * @author  Dustin Huynh <dustinhuynh@catalyst-au.net>
+ * @copyright 2026 Catalyst IT
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \tool_cloudmetrics\metric\yearly_active_users_metric
+ */
+final class tool_cloudmetrics_yearly_active_users_test extends \advanced_testcase {
+    /** @var array[] Sample active user DB data to be used in tests. */
+    public const ACTIVE_USER_DATA = [
+        ['username' => 'a', 'confirmed' => 1, 'lastlogin' => DAYSECS + 1000],
+        ['username' => 'b', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 2) + 1000],
+        ['username' => 'c', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 2) + 2000],
+        ['username' => 'd', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 2) + 3000],
+        ['username' => 'e', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 3) + 1000],
+        ['username' => 'f', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 3) + 2000],
+        ['username' => 'g', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 4) + 1000],
+        ['username' => 'h', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 4) + 2000],
+        ['username' => 'i', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 5) + 1000],
+        ['username' => 'j', 'confirmed' => 1, 'lastlogin' => (DAYSECS * 5) + 2000],
+    ];
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Tests test_generate_yearly_active_users_metric() for the builtin user metrics.
+     *
+     * @dataProvider data_for_test_generate_yearly_active_users_metric
+     * @param string $metricname The name of the metric to be tested.
+     * @param array $expected List of metric items that expect to be generated.
+     * @throws \dml_exception
+     */
+    public function test_generate_yearly_active_users_metric(string $metricname, array $expected): void {
+        global $DB;
+
+        foreach (self::ACTIVE_USER_DATA as $row) {
+            $DB->insert_record('user', (object) $row);
+        }
+        $time = DAYSECS * 366;
+        $endtime = $time + (4 * lib::FREQ_TIMES[metric\manager::FREQ_DAY]);
+        $metrictypes = metric\manager::get_metrics(false);
+        $metric = $metrictypes[$metricname];
+        $this->assertEquals($metricname, $metric->get_name());
+        while ($time <= $endtime) {
+            $items[] = $metric->generate_metric_item(0, $time);
+            $time = lib::get_next_time($time, metric\manager::FREQ_DAY);
+        }
+        $this->assertEquals($expected, $items);
+    }
+
+    /**
+     * Data provider for test_generate_yearly_active_users_metric.
+     *
+     * @return array[]
+     */
+    public static function data_for_test_generate_yearly_active_users_metric(): array {
+        $yearlyactiveusers = new yearly_active_users_metric();
+
+        return [
+            ['yearlyactiveusers', [
+                new metric_item('yearlyactiveusers', DAYSECS * 366, 10, $yearlyactiveusers),
+                new metric_item('yearlyactiveusers', DAYSECS * 367, 9, $yearlyactiveusers),
+                new metric_item('yearlyactiveusers', DAYSECS * 368, 6, $yearlyactiveusers),
+                new metric_item('yearlyactiveusers', DAYSECS * 369, 4, $yearlyactiveusers),
+                new metric_item('yearlyactiveusers', DAYSECS * 370, 2, $yearlyactiveusers),
+            ]],
+        ];
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025082000;
-$plugin->release = 2025072301;
+$plugin->version = 2025082001;
+$plugin->release = 2025082001;
 
 $plugin->requires = 2024042200;    // Our lowest supported Moodle (4.4.0).
 


### PR DESCRIPTION
Resolves #207 

- Make saving info about backfills the responsibility of the collector.
- Fix deprecation issues, and CS issues in files changed.
- Move yearly_active_users tests into a separate test class.
- Remove cltr_database_test::test_backfillable_metric() as it does not test anything already tested elsewhere.