### PR TITLE
Issue #216: Extra logging

### DIFF
--- a/classes/collector/base.php
+++ b/classes/collector/base.php
@@ -39,15 +39,15 @@ abstract class base {
      * Records a number of metrics.
      *
      * @param array $metrics
-     * @param \progress_bar|null $progress
-     * @return mixed
+     * @param callable|null $progress
      */
-    public function record_metrics(array $metrics, \progress_bar $progress = null) {
+    public function record_metrics(array $metrics, ?callable $progress = null) {
         $count = 0;
         foreach ($metrics as $metric) {
             $this->record_metric($metric);
             if ($progress) {
-                $progress->update(
+                call_user_func(
+                    $progress,
                     $count,
                     count($metrics),
                     get_string('backfillsaving', 'tool_cloudmetrics', $metric->name)

--- a/classes/metric/base.php
+++ b/classes/metric/base.php
@@ -197,14 +197,14 @@ abstract class base {
     }
 
     /**
-     * Returns records for backfilled metric.
+     * Generates a number of metric items for a period of time.
      *
-     * @param int $backwardperiod Time from which sample is to be retrieved.
-     * @param int $finishtime If data is being completed argument is passed here.
+     * @param int $backwardperiod Time period to draw data from (relative to $finishtime).
+     * @param int|null $finishtime The end time to draw data from. Defaults to now.
      *
-     * @return \Iterator
+     * @return \Iterator Iterator of metric_item in reverse chronological order (most recent first).
      */
-    public function generate_metric_items(int $backwardperiod, int $finishtime = null): \Iterator {
+    public function generate_metric_items(int $backwardperiod, ?int $finishtime = null): \Iterator {
         return new \EmptyIterator();
     }
 

--- a/classes/metric/test_metric.php
+++ b/classes/metric/test_metric.php
@@ -154,6 +154,6 @@ class test_metric extends base {
         for ($time = $start; $time <= $finishtime; $time = lib::get_next_time($time, $this->get_frequency())) {
             $items[] = $this->generate_metric_item(lib::get_previous_time($time, $this->get_frequency()), $time);
         }
-        return new \ArrayIterator($items);
+        return new \ArrayIterator(array_reverse($items));
     }
 }

--- a/classes/task/autobackfill_metrics_task.php
+++ b/classes/task/autobackfill_metrics_task.php
@@ -29,11 +29,53 @@ use tool_cloudmetrics\plugininfo\cltr;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class autobackfill_metrics_task extends \core\task\adhoc_task {
+    /** @var int Number of records saved for each dot displayed */
+    private const NUM_PER_DOT = 10;
+
+    /** @var int Number of dots to be displayed on each line. */
+    private const DOTS_PER_LINE = 80;
+
     /** @var array Enabled plugins */
     private array $plugins;
 
     /** @var ?\tool_cloudmetrics\collector\base  */
     private ?\tool_cloudmetrics\collector\base $collector  = null;
+
+    /** @var int Used to control the printing of progress dots. */
+    private static $progresscount = 0;
+
+    /**
+     * Callback for metric recording progress.
+     *
+     * @param $count int Current count
+     * @param $total int Expected total
+     */
+    public static function progress_calllback(int $count, int $total) {
+        ++self::$progresscount;
+        if (self::$progresscount % self::NUM_PER_DOT != 0) {
+            return;
+        }
+        if (self::$progresscount % (self::NUM_PER_DOT * self::DOTS_PER_LINE) == 0) {
+            $percent = '';
+            // Printing a running percentage only makes sense if we are batch processing.
+            if ($total != 1) {
+                $percent = ' ' . round(($count / $total) * 100) . '%';
+            }
+            mtrace(".$percent");
+        } else {
+            mtrace('.', '');
+        }
+    }
+
+    /**
+     * Reset the progress counter.
+     */
+    public static function reset_progress() {
+        if (self::$progresscount % (self::NUM_PER_DOT * self::DOTS_PER_LINE) != 0) {
+            mtrace('');
+        }
+        self::$progresscount = 0;
+    }
 
     /**
      * Get task name
@@ -54,17 +96,15 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
             return;
         }
         if (!empty($this->collector)) {
-            $this->collector->record_metrics($metricitems);
-            mtrace(sprintf("Recorded %s '%s' metrics", count($metricitems), $metricclass->get_name()));
+            $this->collector->record_metrics($metricitems, [self::class, 'progress_calllback']);
         } else {
             foreach ($this->plugins as $plugin) {
                 $collector = $plugin->get_collector();
                 if ($collector->supports_backfillable_metrics()) {
-                    $collector->record_metrics($metricitems);
+                    $collector->record_metrics($metricitems, [self::class, 'progress_calllback']);
                     if ($collector->is_readable()) {
                         $collector->set_last_backfilled_frequency($metricclass->get_name(), $metricclass->get_frequency());
                     }
-                    mtrace(sprintf("Recorded %s '%s' metrics to %s", count($metricitems), $metricclass->get_name(), $plugin->name));
                 }
             }
         }
@@ -106,6 +146,9 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
         $autobackfill = !isset($customdata->metric);
         $metrictypes = metric\manager::get_metrics(true);
 
+        // TODO: When it is set to run automatically, idempotency is not used. With the current design, idempotency can
+        // only work when the there is one collector being used.
+
         // Filter to a specific metric.
         if (isset($customdata->metric)) {
             $metric = $customdata->metric;
@@ -121,6 +164,7 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
 
         $total = 0;
         foreach ($metrictypes as $metrictype) {
+            mtrace('Visiting metric ' . $metrictype->get_name());
             if (!$metrictype->is_ready()) {
                 continue;
             }
@@ -163,25 +207,37 @@ class autobackfill_metrics_task extends \core\task\adhoc_task {
             ));
 
             $metrics = $metrictype->generate_metric_items($collectingperiod, $finishtime);
-            if ($metrictype->is_backfill_incremental()) {
-                // This metric is slow, so we want to send metrics to the collector as soon as each one is obtained.
-                $count = 0;
-                foreach ($metrics as $metric) {
-                    $this->backfill_metrics($metrictype, [$metric]);
-                    $count++;
-                }
-            } else {
-                // Process the metrics as a batch.
-                $metrics = iterator_to_array($metrics);
-                if ($metrics) {
-                    $this->backfill_metrics($metrictype, $metrics);
-                }
-                $count = count($metrics);
-            }
+            mtrace('Finished generating metrics');
 
-            mtrace(sprintf('Generated %s %s metrics', $count, $metrictype->get_name()));
+            $count = 0;
+            try {
+                if ($metrictype->is_backfill_incremental()) {
+                    // This metric is slow, so we want to send metrics to the collector as soon as each one is obtained.
+                    mtrace('Slow metric. Process with an iterator.');
+                    foreach ($metrics as $metric) {
+                        $this->backfill_metrics($metrictype, [$metric]);
+                        $count++;
+                    }
+                } else {
+                    // Process the metrics as a batch.
+                    mtrace('Process with an array.');
+                    $metrics = iterator_to_array($metrics);
+                    mtrace('There are ' . count($metrics) . ' to process.');
+                    if ($metrics) {
+                        $this->backfill_metrics($metrictype, $metrics);
+                    }
+                    $count = count($metrics);
+                }
+                self::reset_progress();
+            } catch (\Exception $e) {
+                self::reset_progress();
+                mtrace('Error occurred: ' . $e->getMessage());
+            }
+            mtrace('Processed ' . $count . ' metrics.');
+
             $total += $count;
+            mtrace('Finished with metric ' . $metrictype->get_name());
         }
-        mtrace('Backfilled totally ' . $total . ' metrics');
+        mtrace('Backfilled a total of ' . $total . ' metrics');
     }
 }

--- a/collector/cloudwatch/classes/collector.php
+++ b/collector/cloudwatch/classes/collector.php
@@ -75,10 +75,9 @@ class collector extends base {
      * Record an array of metric data
      *
      * @param array $items
-     * @param \progress_bar|null $progress
-     * @return mixed
+     * @param callable|null $progress
      */
-    public function record_metrics(array $items, \progress_bar $progress = null) {
+    public function record_metrics(array $items, ?callable $progress = null) {
         $metricdata = [];
         foreach ($items as $item) {
             $metricdata[] = $this->make_metric_data_entry($item);

--- a/collector/database/classes/collector.php
+++ b/collector/database/classes/collector.php
@@ -49,21 +49,6 @@ class collector extends readable_base {
     }
 
     /**
-     * Records a number of metrics.
-     *
-     * @param array $metrics
-     * @param ?\progress_bar $progress
-     */
-    public function record_metrics(array $metrics, ?\progress_bar $progress = null) {
-        global $DB;
-        if (count($metrics) !== 0) {
-            $transaction = $DB->start_delegated_transaction();
-            parent::record_metrics($metrics, $progress);
-            $transaction->allow_commit();
-        }
-    }
-
-    /**
      * Deletes every metric from cltr table for a given metric name.
      *
      * @param string $metricname Metric name to remove.

--- a/collector/database/classes/task/metrics_cleanup_task.php
+++ b/collector/database/classes/task/metrics_cleanup_task.php
@@ -51,12 +51,19 @@ class metrics_cleanup_task extends \core\task\scheduled_task {
             // always have at least the expiry value in time's worth of data.
             $cutoff = lib::get_midnight_of($datestr, $tz)->getTimestamp();
 
+            mtrace('Cutoff timestamp is ' . date(DATE_RSS, $cutoff));
+
+            $precount = $DB->count_records(lib::TABLE);
             // Purge the metrics older than this time.
             $DB->delete_records_select(
                 lib::TABLE,
                 'time < :cutoff',
                 ['cutoff' => $cutoff]
             );
+            $postcount = $DB->count_records(lib::TABLE);
+            mtrace('Purged ' . ($precount - $postcount) . ' records.');
+        } else {
+            mtrace('Expiry is set to zero. No purging done.');
         }
     }
 }

--- a/collector/database/tests/cltr_database_test.php
+++ b/collector/database/tests/cltr_database_test.php
@@ -243,7 +243,9 @@ final class cltr_database_test extends \tool_cloudmetrics\metric_testcase {
         set_config('metric_expiry', $expiry, 'cltr_database');
 
         $task = new \cltr_database\task\metrics_cleanup_task();
+        ob_start();
         $task->execute();
+        ob_end_clean();
 
         // There should now be only $numexpected items in the database.
         $count = $DB->count_records(lib::TABLE);


### PR DESCRIPTION
- Make sure generate_metric_items() gives data is reverse chrono order.
- Replace progress_bar with a callback.
- Have backfill task print dots as progress.
- Remove transaction from database collector.